### PR TITLE
address some lintr concerns

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -5,37 +5,55 @@
 #' @title AbstractAnnData
 #'
 #' @description
-#' Abstract [R6][R6::R6Class] class representing an AnnData object. Defines the interface.
+#'   Abstract [R6][R6::R6Class] class representing an AnnData
+#'   object. Defines the interface.
 #' @importFrom R6 R6Class
 AbstractAnnData <- R6::R6Class("AbstractAnnData",
   active = list(
-    #' @field X NULL or an observation x variable matrix (without dimnames) consistent with the number of rows of `obs` and `var`.
+    #' @field X NULL or an observation x variable matrix (without
+    #'   dimnames) consistent with the number of rows of `obs` and `var`.
     X = function(value) {
       .abstract_function()
     },
-    #' @field layers The layers slot. Must be NULL or a named list with with all elements having the dimensions consistent with `obs` and `var`.
+    #' @field layers The layers slot. Must be NULL or a named list
+    #'   with with all elements having the dimensions consistent with
+    #'   `obs` and `var`.
     layers = function(value) {
       .abstract_function()
     },
-    #' @field obs A `data.frame` with columns containing information about observations. The number of rows of `obs` defines the observation dimension of the AnnData object.
+    #' @field obs A `data.frame` with columns containing information
+    #'   about observations. The number of rows of `obs` defines the
+    #'   observation dimension of the AnnData object.
     obs = function(value) {
       .abstract_function()
     },
-    #' @field var A `data.frame` with columns containing information about variables. The number of rows of `var` defines the variable dimension of the AnnData object.
+    #' @field var A `data.frame` with columns containing information
+    #'   about variables. The number of rows of `var` defines the variable
+    #'   dimension of the AnnData object.
     var = function(value) {
       .abstract_function()
     },
-    #' @field obs_names Either NULL or a vector of unique identifiers used to identify each row of `obs` and to act as an index into the observation dimension of the AnnData object. For compatibility with *R* representations, `obs_names` should be a character vector.
+    #' @field obs_names Either NULL or a vector of unique identifiers
+    #'   used to identify each row of `obs` and to act as an index into
+    #'   the observation dimension of the AnnData object. For
+    #'   compatibility with *R* representations, `obs_names` should be a
+    #'   character vector.
     obs_names = function(value) {
       .abstract_function()
     },
-    #' @field var_names Either NULL or a vector of unique identifiers used to identify each row of `var` and to act as an index into the variable dimension of the AnnData object.. For compatibility with *R* representations, `var_names` should be a character vector.
+    #' @field var_names Either NULL or a vector of unique identifiers
+    #'   used to identify each row of `var` and to act as an index into
+    #'   the variable dimension of the AnnData object.. For compatibility
+    #'   with *R* representations, `var_names` should be a character
+    #'   vector.
     var_names = function(value) {
       .abstract_function()
     }
   ),
   public = list(
-    #' @description Print a summary of the AnnData object. `print()` methods should be implemented so that they are not computationally expensive.
+    #' @description Print a summary of the AnnData object. `print()`
+    #'   methods should be implemented so that they are not
+    #'   computationally expensive.
     #' @param ... Optional arguments to print method.
     print = function(...) {
       X_info <- if (!is.null(self$X)) {
@@ -53,7 +71,9 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
         sep = ""
       )
     },
+
     #' @description Dimensions (observations x variables) of the AnnData object.
+
     shape = function() {
       c(
         nrow(self$obs),
@@ -76,7 +96,8 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     var_keys = function() {
       names(self$var)
     },
-    #' @description Create an AnnData object with all fields loaded into memory.
+    #' @description Create an AnnData object with all fields loaded
+    #'   into memory.
     to_inmemory = function() {
       # should probably be stored in a separate file
       InMemoryAnnData$new(

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -35,7 +35,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData",
   ),
   public = list(
     #' @description HDF5AnnData constructor
-    #' 
+    #'
     #' @param h5obj The rhdf5 object
     initialize = function(h5obj) {
       private$.h5obj <- h5obj

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -2,7 +2,7 @@
 #'
 #' @description
 #' Implementation of an in memory AnnData object.
-#' 
+#'
 #' @importFrom Matrix as.matrix
 #'
 #' @examples
@@ -46,31 +46,43 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
     .obs_names = NULL,
     .var_names = NULL,
 
-    # @description `.validate_matrix()` checks that dimensions are consistent with `obs` and `var`, and removes dimnames if present.
+    # @description `.validate_matrix()` checks that dimensions are
+    #   consistent with `obs` and `var`, and removes dimnames if
+    #   present.
     # @param mat A matrix to validate
-    # @param label Must be `"X"` or `"layer[[...]]"` where `...` is the name of a layer.
+    # @param label Must be `"X"` or `"layer[[...]]"` where `...` is
+    #   the name of a layer.
     .validate_matrix = function(mat, label) {
       if (!is.null(mat)) {
         if (nrow(mat) != nrow(self$obs))
           stop("nrow(", label, ") should be the same as nrow(obs)")
         if (ncol(mat) != nrow(self$var))
           stop("ncol(", label, ") should be the same as nrow(var)")
-      
+
         if (!is.null(rownames(mat))) {
-          warning("rownames(", label, ") should be NULL, removing them from the matrix")
+          warning(wrap_message(
+            "rownames(", label, ") should be NULL, removing them from the ",
+            "matrix"
+          ))
           rownames(mat) <- NULL
         }
-      
+
         if (!is.null(colnames(mat))) {
-          warning("colnames(", label, ") should be NULL, removing them from the matrix")
+          warning(wrap_message(
+            "colnames(", label, ") should be NULL, removing them from the ",
+            "matrix"
+          ))
           colnames(mat) <- NULL
         }
       }
 
       mat
     },
-    # @description `.validate_layers()` checks for named lists and correct dimensions on elements.
-    # @param layers A named list of 0 or more matrix elements with dimensions consistent with `obs` and `var`.
+
+    # @description `.validate_layers()` checks for named lists and
+    #   correct dimensions on elements.
+    # @param layers A named list of 0 or more matrix elements with
+    #   dimensions consistent with `obs` and `var`.
     .validate_layers = function(layers) {
       if (is.null(layers)) return(layers)
 
@@ -91,30 +103,41 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
 
       layers
     },
-    # @description `.validate_obsvar_dataframe()` checks that the object is a data.frame and removes explicit dimnames.
+
+    # @description `.validate_obsvar_dataframe()` checks that the
+    #   object is a data.frame and removes explicit dimnames.
     # @param df A data frame to validate. Should be an obs or a var.
     # @param label Must be `"obs"` or `"var"`
     .validate_obsvar_dataframe = function(df, label) {
       if (is.null(df)) stop(label, " should be a data frame")
       if (.row_names_info(df) > 0) {
-        warning(label, " should not have any dimnames, removing them from the matrix")
+        warning(wrap_message(
+          "'", label, "' should not have any dimnames, removing them from ",
+          "the matrix"
+        ))
         rownames(df) <- NULL
       }
       df
     },
 
-    # @description `.validate_obsvar_names()` checks that `*_names()` are NULL or consistent with the dimensions of `obs` or `var`.
+    # @description `.validate_obsvar_names()` checks that `*_names()`
+    #   are NULL or consistent with the dimensions of `obs` or `var`.
     # @param names A vector to validate
     # @param label Must be `"obs"` or `"var"`
     .validate_obsvar_names = function(names, label) {
-      if (!is.null(names)) {
-        if (length(names) != nrow(self[[label]])) stop("length(", label, "_names) should be the same as nrow(", label, ")")
+      if (!is.null(names) && length(names) != nrow(self[[label]])) {
+        stop(wrap_message(
+          "length(", label, "_names) should be the same as ",
+          "nrow(", label, ")"
+        ))
       }
       names
     }
   ),
   active = list(
-    #' @field X NULL or an observation x variable matrix (without dimnames) consistent with the number of rows of `obs` and `var`.
+    #' @field X NULL or an observation x variable matrix (without
+    #'   dimnames) consistent with the number of rows of `obs` and
+    #"   `var`.
     X = function(value) {
       if (missing(value)) {
         private$.X
@@ -123,7 +146,8 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
         self
       }
     },
-    #' @field layers NULL or a named list with all elements having the dimensions consistent with `obs` and `var`.
+    #' @field layers NULL or a named list with all elements having the
+    #'   dimensions consistent with `obs` and `var`.
     layers = function(value) {
       if (missing(value)) {
         private$.layers
@@ -132,7 +156,9 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
         self
       }
     },
-    #' @field obs A `data.frame` with columns containing information about observations. The number of rows of `obs` defines the observation dimension of the AnnData object.
+    #' @field obs A `data.frame` with columns containing information
+    #'   about observations. The number of rows of `obs` defines the
+    #'   observation dimension of the AnnData object.
     obs = function(value) {
       if (missing(value)) {
         private$.obs
@@ -141,7 +167,9 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
         self
       }
     },
-    #' @field var A `data.frame` with columns containing information about variables. The number of rows of `var` defines the variable dimension of the AnnData object.
+    #' @field var A `data.frame` with columns containing information
+    #'   about variables. The number of rows of `var` defines the variable
+    #'   dimension of the AnnData object.
     var = function(value) {
       if (missing(value)) {
         private$.var
@@ -150,7 +178,11 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
         self
       }
     },
-    #' @field obs_names Either NULL or a vector of unique identifiers used to identify each row of `obs` and to act as an index into the observation dimension of the AnnData object. For compatibility with *R* representations, `obs_names` should be a character vector.
+    #' @field obs_names Either NULL or a vector of unique identifiers
+    #'   used to identify each row of `obs` and to act as an index into
+    #'   the observation dimension of the AnnData object. For
+    #'   compatibility with *R* representations, `obs_names` should be a
+    #'   character vector.
     obs_names = function(value) {
       if (missing(value)) {
         private$.obs_names
@@ -159,7 +191,11 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
         self
       }
     },
-    #' @field var_names Either NULL or a vector of unique identifiers used to identify each row of `var` and to act as an index into the variable dimension of the AnnData object.. For compatibility with *R* representations, `var_names` should be a character vector.
+    #' @field var_names Either NULL or a vector of unique identifiers
+    #'   used to identify each row of `var` and to act as an index into
+    #'   the variable dimension of the AnnData object.. For compatibility
+    #'   with *R* representations, `var_names` should be a character
+    #'   vector.
     var_names = function(value) {
       if (missing(value)) {
         private$.var_names
@@ -171,16 +207,33 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData",
   ),
   public = list(
     #' @description Creates a new instance of an in memory AnnData object.
-    #' Inherits from AbstractAnnData.
-    #' 
-    #' @param X Either NULL or a observation x variable matrix with dimensions consistent with `obs` and `var`.
-    #' @param layers Either NULL or a named list, where each element is an observation x variable matrix with dimensions consistent with `obs` and `var`.
-    #' @param obs A `data.frame` with columns containing information about observations. The number of rows of `obs` defines the observation dimension of the AnnData object.
-    #' @param var A `data.frame` with columns containing information about variables. The number of rows of `var` defines the variable dimension of the AnnData object.
-    #' @param obs_names Either NULL or a vector of unique identifiers used to identify each row of `obs` and to act as an index into the observation dimension of the AnnData object. For compatibility with *R* representations, `obs_names` should be a character vector.
-    #' @param var_names Either NULL or a vector of unique identifers used to identify each row of `var` and to act as an index into the variable dimension of the AnnData object.. For compatibility with *R* representations, `var_names` should be a character vector.
-    initialize = function(X = NULL, obs, var, obs_names = NULL, var_names = NULL, layers = NULL) {
-      # check obs and var first, because these objects are used by other validators
+    #'   Inherits from AbstractAnnData.
+    #' @param X Either NULL or a observation x variable matrix with
+    #'   dimensions consistent with `obs` and `var`.
+    #' @param layers Either NULL or a named list, where each element
+    #'   is an observation x variable matrix with dimensions consistent
+    #'   with `obs` and `var`.
+    #' @param obs A `data.frame` with columns containing information
+    #'   about observations. The number of rows of `obs` defines the
+    #'   observation dimension of the AnnData object.
+    #' @param var A `data.frame` with columns containing information
+    #'   about variables. The number of rows of `var` defines the variable
+    #'   dimension of the AnnData object.
+    #' @param obs_names Either NULL or a vector of unique identifiers
+    #'   used to identify each row of `obs` and to act as an index into
+    #'   the observation dimension of the AnnData object. For
+    #'   compatibility with *R* representations, `obs_names` should be a
+    #'   character vector.
+    #' @param var_names Either NULL or a vector of unique identifers
+    #'   used to identify each row of `var` and to act as an index into
+    #'   the variable dimension of the AnnData object.. For compatibility
+    #'   with *R* representations, `var_names` should be a character
+    #'   vector.
+    initialize = function(
+      X = NULL, obs, var, obs_names = NULL, var_names = NULL, layers = NULL
+    ) {
+      # check obs and var first, because these objects are used by
+      # other validators
       private$.obs <- private$.validate_obsvar_dataframe(obs, "obs")
       private$.var <- private$.validate_obsvar_dataframe(var, "var")
 

--- a/R/SingleCellExperiment.R
+++ b/R/SingleCellExperiment.R
@@ -37,10 +37,14 @@ to_SingleCellExperiment <- function(object) {
 
     sce <- SingleCellExperiment::SingleCellExperiment(
         assays = assay,
-        colData = S4Vectors::DataFrame(object$obs, row.names = object$obs_names),
-        rowData = S4Vectors::DataFrame(object$var, row.names = object$var_names),
+        colData = S4Vectors::DataFrame(
+            object$obs, row.names = object$obs_names
+        ),
+        rowData = S4Vectors::DataFrame(
+            object$var, row.names = object$var_names
+        ),
         metadata = list(),
-        ## FIXME: metadata = object$uns
+        ## FIXME: assign object$uns to metadata
         checkDimnames = TRUE
     )
 

--- a/R/to_Seurat.R
+++ b/R/to_Seurat.R
@@ -1,9 +1,9 @@
 #' Convert an AnnData object to Seurat
-#' 
+#'
 #' @param obj An AnnData object
-#' 
+#'
 #' @importFrom Matrix t
-#' 
+#'
 #' @export
 #' @examples
 #' ad <- InMemoryAnnData$new(
@@ -41,14 +41,18 @@ to_Seurat <- function(obj) {
 
   # create seurat object
   seurat_obj <- SeuratObject::CreateSeuratObject(X_assay, meta.data = obs_)
-  
+
   seurat_obj
 }
 
 .toseurat_check_obsvar_names <- function(names, label) {
   if (any(grepl("_", names))) {
     # mimic seurat behaviour
-    warning(label, " cannot have underscores ('_') when converting to Seurat, replacing with dashes ('-')")
+    warning(wrap_message(
+      "'", label, "' ",
+      "cannot have underscores ('_') when converting to Seurat, ",
+      "replacing with dashes ('-')"
+    ))
     names <- gsub("_", "-", names)
   }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -1,4 +1,9 @@
 pretty_print <- function(label, value) {
-    txt <- paste0(label, ": ", paste(value, collapse = " "))
-    paste0(strwrap(txt, indent = 0, exdent = 2), collapse = "\n")
+  txt <- paste0(label, ": ", paste(value, collapse = " "))
+  paste0(strwrap(txt, indent = 0, exdent = 2), collapse = "\n")
+}
+
+wrap_message <- function(...) {
+  txt <- paste0(..., collapse = "")
+  paste(strwrap(txt, exdent = 2L), collapse = "\n")
 }

--- a/man/AbstractAnnData.Rd
+++ b/man/AbstractAnnData.Rd
@@ -4,22 +4,38 @@
 \alias{AbstractAnnData}
 \title{AbstractAnnData}
 \description{
-Abstract \link[R6:R6Class]{R6} class representing an AnnData object. Defines the interface.
+Abstract \link[R6:R6Class]{R6} class representing an AnnData
+object. Defines the interface.
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{X}}{NULL or an observation x variable matrix (without dimnames) consistent with the number of rows of \code{obs} and \code{var}.}
+\item{\code{X}}{NULL or an observation x variable matrix (without
+dimnames) consistent with the number of rows of \code{obs} and \code{var}.}
 
-\item{\code{layers}}{The layers slot. Must be NULL or a named list with with all elements having the dimensions consistent with \code{obs} and \code{var}.}
+\item{\code{layers}}{The layers slot. Must be NULL or a named list
+with with all elements having the dimensions consistent with
+\code{obs} and \code{var}.}
 
-\item{\code{obs}}{A \code{data.frame} with columns containing information about observations. The number of rows of \code{obs} defines the observation dimension of the AnnData object.}
+\item{\code{obs}}{A \code{data.frame} with columns containing information
+about observations. The number of rows of \code{obs} defines the
+observation dimension of the AnnData object.}
 
-\item{\code{var}}{A \code{data.frame} with columns containing information about variables. The number of rows of \code{var} defines the variable dimension of the AnnData object.}
+\item{\code{var}}{A \code{data.frame} with columns containing information
+about variables. The number of rows of \code{var} defines the variable
+dimension of the AnnData object.}
 
-\item{\code{obs_names}}{Either NULL or a vector of unique identifiers used to identify each row of \code{obs} and to act as an index into the observation dimension of the AnnData object. For compatibility with \emph{R} representations, \code{obs_names} should be a character vector.}
+\item{\code{obs_names}}{Either NULL or a vector of unique identifiers
+used to identify each row of \code{obs} and to act as an index into
+the observation dimension of the AnnData object. For
+compatibility with \emph{R} representations, \code{obs_names} should be a
+character vector.}
 
-\item{\code{var_names}}{Either NULL or a vector of unique identifiers used to identify each row of \code{var} and to act as an index into the variable dimension of the AnnData object.. For compatibility with \emph{R} representations, \code{var_names} should be a character vector.}
+\item{\code{var_names}}{Either NULL or a vector of unique identifiers
+used to identify each row of \code{var} and to act as an index into
+the variable dimension of the AnnData object.. For compatibility
+with \emph{R} representations, \code{var_names} should be a character
+vector.}
 }
 \if{html}{\out{</div>}}
 }
@@ -40,7 +56,9 @@ Abstract \link[R6:R6Class]{R6} class representing an AnnData object. Defines the
 \if{html}{\out{<a id="method-AbstractAnnData-print"></a>}}
 \if{latex}{\out{\hypertarget{method-AbstractAnnData-print}{}}}
 \subsection{Method \code{print()}}{
-Print a summary of the AnnData object. \code{print()} methods should be implemented so that they are not computationally expensive.
+Print a summary of the AnnData object. \code{print()}
+methods should be implemented so that they are not
+computationally expensive.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{AbstractAnnData$print(...)}\if{html}{\out{</div>}}
 }
@@ -107,7 +125,8 @@ Keys ('column names') of \code{var}.
 \if{html}{\out{<a id="method-AbstractAnnData-to_inmemory"></a>}}
 \if{latex}{\out{\hypertarget{method-AbstractAnnData-to_inmemory}{}}}
 \subsection{Method \code{to_inmemory()}}{
-Create an AnnData object with all fields loaded into memory.
+Create an AnnData object with all fields loaded
+into memory.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{AbstractAnnData$to_inmemory()}\if{html}{\out{</div>}}
 }

--- a/man/InMemoryAnnData.Rd
+++ b/man/InMemoryAnnData.Rd
@@ -42,17 +42,31 @@ ad
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
 \describe{
-\item{\code{X}}{NULL or an observation x variable matrix (without dimnames) consistent with the number of rows of \code{obs} and \code{var}.}
+\item{\code{X}}{NULL or an observation x variable matrix (without
+dimnames) consistent with the number of rows of \code{obs} and}
 
-\item{\code{layers}}{NULL or a named list with all elements having the dimensions consistent with \code{obs} and \code{var}.}
+\item{\code{layers}}{NULL or a named list with all elements having the
+dimensions consistent with \code{obs} and \code{var}.}
 
-\item{\code{obs}}{A \code{data.frame} with columns containing information about observations. The number of rows of \code{obs} defines the observation dimension of the AnnData object.}
+\item{\code{obs}}{A \code{data.frame} with columns containing information
+about observations. The number of rows of \code{obs} defines the
+observation dimension of the AnnData object.}
 
-\item{\code{var}}{A \code{data.frame} with columns containing information about variables. The number of rows of \code{var} defines the variable dimension of the AnnData object.}
+\item{\code{var}}{A \code{data.frame} with columns containing information
+about variables. The number of rows of \code{var} defines the variable
+dimension of the AnnData object.}
 
-\item{\code{obs_names}}{Either NULL or a vector of unique identifiers used to identify each row of \code{obs} and to act as an index into the observation dimension of the AnnData object. For compatibility with \emph{R} representations, \code{obs_names} should be a character vector.}
+\item{\code{obs_names}}{Either NULL or a vector of unique identifiers
+used to identify each row of \code{obs} and to act as an index into
+the observation dimension of the AnnData object. For
+compatibility with \emph{R} representations, \code{obs_names} should be a
+character vector.}
 
-\item{\code{var_names}}{Either NULL or a vector of unique identifiers used to identify each row of \code{var} and to act as an index into the variable dimension of the AnnData object.. For compatibility with \emph{R} representations, \code{var_names} should be a character vector.}
+\item{\code{var_names}}{Either NULL or a vector of unique identifiers
+used to identify each row of \code{var} and to act as an index into
+the variable dimension of the AnnData object.. For compatibility
+with \emph{R} representations, \code{var_names} should be a character
+vector.}
 }
 \if{html}{\out{</div>}}
 }
@@ -96,17 +110,32 @@ Inherits from AbstractAnnData.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{X}}{Either NULL or a observation x variable matrix with dimensions consistent with \code{obs} and \code{var}.}
+\item{\code{X}}{Either NULL or a observation x variable matrix with
+dimensions consistent with \code{obs} and \code{var}.}
 
-\item{\code{obs}}{A \code{data.frame} with columns containing information about observations. The number of rows of \code{obs} defines the observation dimension of the AnnData object.}
+\item{\code{obs}}{A \code{data.frame} with columns containing information
+about observations. The number of rows of \code{obs} defines the
+observation dimension of the AnnData object.}
 
-\item{\code{var}}{A \code{data.frame} with columns containing information about variables. The number of rows of \code{var} defines the variable dimension of the AnnData object.}
+\item{\code{var}}{A \code{data.frame} with columns containing information
+about variables. The number of rows of \code{var} defines the variable
+dimension of the AnnData object.}
 
-\item{\code{obs_names}}{Either NULL or a vector of unique identifiers used to identify each row of \code{obs} and to act as an index into the observation dimension of the AnnData object. For compatibility with \emph{R} representations, \code{obs_names} should be a character vector.}
+\item{\code{obs_names}}{Either NULL or a vector of unique identifiers
+used to identify each row of \code{obs} and to act as an index into
+the observation dimension of the AnnData object. For
+compatibility with \emph{R} representations, \code{obs_names} should be a
+character vector.}
 
-\item{\code{var_names}}{Either NULL or a vector of unique identifers used to identify each row of \code{var} and to act as an index into the variable dimension of the AnnData object.. For compatibility with \emph{R} representations, \code{var_names} should be a character vector.}
+\item{\code{var_names}}{Either NULL or a vector of unique identifers
+used to identify each row of \code{var} and to act as an index into
+the variable dimension of the AnnData object.. For compatibility
+with \emph{R} representations, \code{var_names} should be a character
+vector.}
 
-\item{\code{layers}}{Either NULL or a named list, where each element is an observation x variable matrix with dimensions consistent with \code{obs} and \code{var}.}
+\item{\code{layers}}{Either NULL or a named list, where each element
+is an observation x variable matrix with dimensions consistent
+with \code{obs} and \code{var}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test-InMemoryAnnData.R
+++ b/tests/testthat/test-InMemoryAnnData.R
@@ -181,19 +181,19 @@ test_that("write to X", {
     obs_names = obs_names,
     var_names = var_names
   )
-  
+
   X2 <- Matrix::rsparsematrix(nrow = 10, ncol = 20, density = .1)
   ad$X <- X2
-  
+
   expect_equal(ad$X, X2)
-  
+
   # change row in X
-  ad$X[2,] <- 10
-  expect_equal(ad$X[2,], rep(10, 20L))
-  
+  ad$X[2, ] <- 10
+  expect_equal(ad$X[2, ], rep(10, 20L))
+
   # change column in X
-  ad$X[,3] <- 5
-  expect_equal(ad$X[,3], rep(5, 10L))
+  ad$X[, 3] <- 5
+  expect_equal(ad$X[, 3], rep(5, 10L))
 })
 
 
@@ -205,26 +205,26 @@ test_that("write to obs", {
     obs_names = obs_names,
     var_names = var_names
   )
-  
+
   obs2 <- data.frame(
     foo = sample(letters, 10, replace = TRUE),
     bar = sample.int(4, 10, replace = TRUE),
     zing = sample(c(TRUE, FALSE), 10, replace = TRUE)
   )
   ad$obs <- obs2
-  
+
   expect_equal(ncol(ad$obs), 3)
   expect_equal(nrow(ad$obs), 10)
   expect_equal(ad$obs, obs2)
-  
+
   # change row in obs
   obs2row <- data.frame(foo = "a", bar = 3, zing = FALSE)
-  ad$obs[2,] <- obs2row
-  expect_equal(ad$obs[2,], obs2row, ignore_attr = TRUE)
-  
+  ad$obs[2, ] <- obs2row
+  expect_equal(ad$obs[2, ], obs2row, ignore_attr = TRUE)
+
   # change column in obs
-  ad$obs[,3] <- FALSE
-  expect_equal(ad$obs[,3], rep(FALSE, 10L))
+  ad$obs[, 3] <- FALSE
+  expect_equal(ad$obs[, 3], rep(FALSE, 10L))
 })
 
 test_that("write to var", {
@@ -235,26 +235,26 @@ test_that("write to var", {
     obs_names = obs_names,
     var_names = var_names
   )
-  
+
   var2 <- data.frame(
     foo = sample(letters, 20L, replace = TRUE),
     bar = sample.int(4, 20L, replace = TRUE),
     zing = sample(c(TRUE, FALSE), 20L, replace = TRUE)
   )
   ad$var <- var2
-  
+
   expect_equal(ncol(ad$var), 3)
   expect_equal(nrow(ad$var), 20)
   expect_equal(ad$var, var2)
-  
+
   # change row in var
   var2row <- data.frame(foo = "a", bar = 3, zing = FALSE)
-  ad$var[2,] <- var2row
-  expect_equal(ad$var[2,], var2row, ignore_attr = TRUE)
-  
+  ad$var[2, ] <- var2row
+  expect_equal(ad$var[2, ], var2row, ignore_attr = TRUE)
+
   # change column in var
-  ad$var[,3] <- FALSE
-  expect_equal(ad$var[,3], rep(FALSE, 20L))
+  ad$var[, 3] <- FALSE
+  expect_equal(ad$var[, 3], rep(FALSE, 20L))
 })
 
 
@@ -266,12 +266,12 @@ test_that("write to obs_names", {
     obs_names = obs_names,
     var_names = var_names
   )
-  
+
   obs_names2 <- letters[1:10]
   ad$obs_names <- obs_names2
-  
+
   expect_equal(ad$obs_names, obs_names2)
-  
+
   # change value in obs_names
   ad$obs_names[2:3] <- c("foo", "bar")
   expect_equal(ad$obs_names[1:4], c("a", "foo", "bar", "d"))
@@ -285,12 +285,12 @@ test_that("write to var_names", {
     obs_names = obs_names,
     var_names = var_names
   )
-  
+
   var_names2 <- LETTERS[1:20]
   ad$var_names <- var_names2
-  
+
   expect_equal(ad$var_names, var_names2)
-  
+
   # change value in var_names
   ad$var_names[2:3] <- c("foo", "bar")
   expect_equal(ad$var_names[1:4], c("A", "foo", "bar", "D"))

--- a/tests/testthat/test-to_seurat.R
+++ b/tests/testthat/test-to_seurat.R
@@ -36,7 +36,7 @@ test_that("to_Seurat with inmemoryanndata", {
   expect_equal(ncol(seu), 10)
   expect_equal(rownames(seu), var_names)
   expect_equal(colnames(seu), obs_names)
-  
+
   # todo: check whether X can be retrieved
 })
 


### PR DESCRIPTION
- wrap long lines, including in message / warning / stop, with wrap_message()
- wrapped documentation lines are indented, rather than, e.g., separated by blank lines
- if the body of a call `(` needs to be wrapped, then the opening `(` is followed by a new line, and the closing `)` is on a line by itself
   ```
  some_thing(or_another(
     ...
  ))
   ```
- long function arguments try to adopt the principle that all indents should be 2 spaces more than the parent, rather than indented to the opening `(` or similar
  ```
  xx <- function(
    one_param, <...>
  )
  ```
- not addressed: capitalization (false positive); cyclomatic complexity