### PR TITLE
Add remaining slots to AbstractAnnData

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -27,26 +27,12 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     obs = function(value) {
       .abstract_function()
     },
-    #' @field var A `data.frame` with columns containing information
-    #'   about variables. The number of rows of `var` defines the variable
-    #'   dimension of the AnnData object.
-    var = function(value) {
-      .abstract_function()
-    },
     #' @field obs_names Either NULL or a vector of unique identifiers
     #'   used to identify each row of `obs` and to act as an index into
     #'   the observation dimension of the AnnData object. For
     #'   compatibility with *R* representations, `obs_names` should be a
     #'   character vector.
     obs_names = function(value) {
-      .abstract_function()
-    },
-    #' @field var_names Either NULL or a vector of unique identifiers
-    #'   used to identify each row of `var` and to act as an index into
-    #'   the variable dimension of the AnnData object. For compatibility
-    #'   with *R* representations, `var_names` should be a character
-    #'   vector.
-    var_names = function(value) {
       .abstract_function()
     },
     #' @field obsm The obsm slot. Must be NULL or a named list
@@ -64,6 +50,20 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     #' @field uns The uns slot. Must be NULL or a named list or arbitrary
     #' objects.
     uns = function(value) {
+      .abstract_function()
+    },
+    #' @field var A `data.frame` with columns containing information
+    #'   about variables. The number of rows of `var` defines the variable
+    #'   dimension of the AnnData object.
+    var = function(value) {
+      .abstract_function()
+    },
+    #' @field var_names Either NULL or a vector of unique identifiers
+    #'   used to identify each row of `var` and to act as an index into
+    #'   the variable dimension of the AnnData object. For compatibility
+    #'   with *R* representations, `var_names` should be a character
+    #'   vector.
+    var_names = function(value) {
       .abstract_function()
     },
     #' @field varm The varm slot. Must be NULL or a named list
@@ -100,9 +100,7 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
         sep = ""
       )
     },
-
     #' @description Dimensions (observations x variables) of the AnnData object.
-
     shape = function() {
       c(
         nrow(self$obs),
@@ -117,17 +115,13 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     n_vars = function() {
       nrow(self$var)
     },
-    #' @description Keys ('column names') of `obs`.
-    obs_keys = function() {
-      names(self$obs)
-    },
-    #' @description Keys ('column names') of `var`.
-    var_keys = function() {
-      names(self$var)
-    },
     #' @description Keys (element names) of `layers`.
     layers_keys = function() {
       names(self$layers)
+    },
+    #' @description Keys ('column names') of `obs`.
+    obs_keys = function() {
+      names(self$obs)
     },
     #' @description Keys ('item names') of `obsm`.
     obsm_keys = function() {
@@ -136,6 +130,10 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     #' @description Keys ('item names') of `uns`.
     uns_keys = function() {
       names(self$uns)
+    },
+    #' @description Keys ('column names') of `var`.
+    var_keys = function() {
+      names(self$var)
     },
     #' @description Keys ('item names') of `varm`.
     varm_keys = function() {

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -128,6 +128,18 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     #' @description Keys (element names) of `layers`.
     layers_keys = function() {
       names(self$layers)
+    },
+    #' @description Keys ('item names') of `obsm`.
+    obsm_keys = function() {
+      names(self$obsm)
+    },
+    #' @description Keys ('item names') of `uns`.
+    uns_keys = function() {
+      names(self$uns)
+    },
+    #' @description Keys ('item names') of `varm`.
+    varm_keys = function() {
+      names(self$varm)
     }
   )
 )

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -43,10 +43,39 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData",
     },
     #' @field var_names Either NULL or a vector of unique identifiers
     #'   used to identify each row of `var` and to act as an index into
-    #'   the variable dimension of the AnnData object.. For compatibility
+    #'   the variable dimension of the AnnData object. For compatibility
     #'   with *R* representations, `var_names` should be a character
     #'   vector.
     var_names = function(value) {
+      .abstract_function()
+    },
+    #' @field obsm The obsm slot. Must be NULL or a named list
+    #'   of two (or more) dimensional arrays with number of rows
+    #'   (first dimension) consistent with `obs`.
+    obsm = fun = function(value) {
+      .abstract_function()
+    },
+    #' @field obsp The obsp slot. Must be NULL or a named list
+    #'   of two (or more) dimensional arrays with number of rows and columns
+    #'   (first two dimensions) consistent with `obs`.
+    obsp = function(value) {
+      .abstract_function()
+    },
+    #' @field uns The uns slot. Must be NULL or a named list or arbitrary
+    #' objects.
+    uns = function(value) {
+      .abstract_function()
+    },
+    #' @field varm The varm slot. Must be NULL or a named list
+    #'   of two (or more) dimensional arrays with number of rows
+    #'   (first dimension) consistent with `var`.
+    varm = fun = function(value) {
+      .abstract_function()
+    },
+    #' @field varp The varp slot. Must be NULL or a named list
+    #'   of two (or more) dimensional arrays with number of rows and columns
+    #'   (first two dimensions) consistent with `var`.
+    varp = function(value) {
       .abstract_function()
     }
   ),


### PR DESCRIPTION
Add remaining slots to `AbstractAnnData` so that these features can be implemented in the other interfaces. There are a few things to consider before this is merged:

**Raw**

I haven't a slot for `.raw` yet because I think it needs some more thought, we might need another class for this and/or to modify the existing classes. Not sure if we should deal with that now or leave it for another PR.

**Interface inconsistencies**

Not sure how important this is but there are some inconsistencies in what we have implemented as "attributes" vs "methods" (if you consider `active` as equivalent to a Python attribute and `public` as equivalent to a Python method).

- `n_obs`, `n_vars`, `shape` are Python attributes but we have them in `public`.
- We have `layer_keys` which doesn't exist in Python (at least not in the documentation)