### PR TITLE
passthrough arguments

### DIFF
--- a/R/read_h5ad.R
+++ b/R/read_h5ad.R
@@ -3,31 +3,45 @@
 #' Read data from a H5AD file
 #'
 #' @param path Path to the H5AD file to read
-#' @param to The type of object to return. Must be one of: "SingleCellExperiment",
-#'   "Seurat", "HDF5AnnData", "InMemoryAnnData"
+#' @param to The type of object to return. Must be one of: "InMemoryAnnData",
+#'   "HDF5AnnData", "SingleCellExperiment", "Seurat"
+#' @param ... Extra arguments provided to [to_SingleCellExperiment()] or
+#'   [to_Seurat()]
 #'
 #' @return The object specified by `to`
 #' @export
 #'
 #' @examples
 #' h5ad_file <- system.file("extdata", "example.h5ad", package = "anndataR")
+#'
 #' # Read the H5AD as a SingleCellExperiment object
 #' if (requireNamespace("SingleCellExperiment", quietly = TRUE)) {
 #'   sce <- read_h5ad(h5ad_file, to = "SingleCellExperiment")
 #' }
+#'
 #' # Read the H5AD as a Seurat object
 #' if (requireNamespace("SeuratObject", quietly = TRUE)) {
 #'   seurat <- read_h5ad(h5ad_file, to = "Seurat")
 #' }
-read_h5ad <- function(path, to = c("SingleCellExperiment", "Seurat", "HDF5AnnData", "InMemoryAnnData")) {
+read_h5ad <- function(
+  path,
+  to = c("InMemoryAnnData", "HDF5AnnData", "SingleCellExperiment", "Seurat"),
+  ...
+) {
   to <- match.arg(to)
 
   adata <- HDF5AnnData$new(path)
 
-  switch(to,
-    "SingleCellExperiment" = to_SingleCellExperiment(adata),
-    "Seurat" = to_Seurat(adata),
-    "HDF5AnnData" = adata,
-    "InMemoryAnnData" = to_InMemoryAnnData(adata)
+  fun <- switch(to,
+    "SingleCellExperiment" = to_SingleCellExperiment,
+    "Seurat" = to_Seurat,
+    "InMemoryAnnData" = to_InMemoryAnnData,
+    "HDF5AnnData" = NULL
   )
+
+  if (!is.null(fun)) {
+    fun(adata, ...)
+  } else {
+    adata
+  }
 }

--- a/man/read_h5ad.Rd
+++ b/man/read_h5ad.Rd
@@ -6,14 +6,18 @@
 \usage{
 read_h5ad(
   path,
-  to = c("SingleCellExperiment", "Seurat", "HDF5AnnData", "InMemoryAnnData")
+  to = c("InMemoryAnnData", "HDF5AnnData", "SingleCellExperiment", "Seurat"),
+  ...
 )
 }
 \arguments{
 \item{path}{Path to the H5AD file to read}
 
-\item{to}{The type of object to return. Must be one of: "SingleCellExperiment",
-"Seurat", "HDF5AnnData", "InMemoryAnnData"}
+\item{to}{The type of object to return. Must be one of: "InMemoryAnnData",
+"HDF5AnnData", "SingleCellExperiment", "Seurat"}
+
+\item{...}{Extra arguments provided to \code{\link[=to_SingleCellExperiment]{to_SingleCellExperiment()}} or
+\code{\link[=to_Seurat]{to_Seurat()}}}
 }
 \value{
 The object specified by \code{to}
@@ -23,10 +27,12 @@ Read data from a H5AD file
 }
 \examples{
 h5ad_file <- system.file("extdata", "example.h5ad", package = "anndataR")
+
 # Read the H5AD as a SingleCellExperiment object
 if (requireNamespace("SingleCellExperiment", quietly = TRUE)) {
   sce <- read_h5ad(h5ad_file, to = "SingleCellExperiment")
 }
+
 # Read the H5AD as a Seurat object
 if (requireNamespace("SeuratObject", quietly = TRUE)) {
   seurat <- read_h5ad(h5ad_file, to = "Seurat")


### PR DESCRIPTION
* allow passing through additional arguments to `to_Seurat` and `to_SingleCellExperiment`

* Change the default to InMemory (similar to python anndata)