### PR TITLE
Tell RStudio to strip trailing whitespace

### DIFF
--- a/anndataR.Rproj
+++ b/anndataR.Rproj
@@ -12,6 +12,8 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+StripTrailingWhitespace: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
Set `StripTrailingWhitespace: Yes` in `anndataR.Rproj` so that RStudio strips trailing whitespace when files are saved (and **{lintr}** can stop complaining 😸).

Alternatively, we can remove `anndata.Rproj` from the repo which is preferred/required by Bioconductor anyway.