### PR TITLE
Hdf5r rownames rework

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,7 @@ Suggests:
     BiocStyle,
     knitr,
     reticulate,
-    rhdf5,
+    hdf5r,
     rmarkdown,
     S4Vectors,
     SeuratObject,
@@ -85,3 +85,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.2.3
 biocViews: SingleCell, DataImport, DataRepresentation
+Remotes: github::rcannood/hdf5r@issue-208-solution

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,3 +85,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.2.3
 biocViews: SingleCell, DataImport, DataRepresentation
+Remotes: github::hhoeflin/hdf5r@bug/fix_empty_attrs_again

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,4 +85,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.2.3
 biocViews: SingleCell, DataImport, DataRepresentation
-Remotes: github::rcannood/hdf5r@issue-208-alternative-condition
+Remotes: github::hhoeflin/hdf5r

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,4 +85,4 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.2.3
 biocViews: SingleCell, DataImport, DataRepresentation
-Remotes: github::rcannood/hdf5r@issue-208-solution
+Remotes: github::rcannood/hdf5r@issue-208-alternative-condition

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -85,4 +85,3 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE, r6 = TRUE)
 RoxygenNote: 7.2.3
 biocViews: SingleCell, DataImport, DataRepresentation
-Remotes: github::hhoeflin/hdf5r

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -284,13 +284,6 @@ AbstractAnnData <- R6::R6Class("AbstractAnnData", # nolint
         ))
       }
 
-      if (has_row_names(df)) {
-        warning(wrap_message(
-          "'", label, "' should not have any rownames, removing them from the data frame."
-        ))
-        rownames(df) <- NULL
-      }
-
       df
     },
 

--- a/R/AnnData.R
+++ b/R/AnnData.R
@@ -8,14 +8,7 @@
 #'
 #' To read an AnnData file from disk, use [read_h5ad()] instead.
 #'
-#' @param obs_names A vector of unique identifiers
-#'   used to identify each row of `obs` and to act as an index into the
-#'   observation dimension of the AnnData object. The length of `obs_names`
-#'   defines the observation dimension of the AnnData object.
-#' @param var_names A vector of unique identifiers used to identify each row
-#'   of `var` and to act as an index into the variable dimension of the
-#'   AnnData object. The length of `var_names` defines the variable
-#'   dimension of the AnnData object.
+#' @param  AnnData object.
 #' @param X Either `NULL` or a observation × variable matrix with
 #'   dimensions consistent with `obs` and `var`.
 #' @param layers Either `NULL` or a named list, where each element is an
@@ -46,22 +39,20 @@
 #'
 #' @examples
 #' adata <- AnnData(
-#'   obs_names = paste0("obs", 1:3),
-#'   var_names = paste0("var", 1:4),
 #'   X = matrix(1:12, nrow = 3, ncol = 4),
 #'   obs = data.frame(
+#'     row.names = paste0("obs", 1:3),
 #'     n_counts = c(1, 2, 3),
 #'     n_cells = c(1, 2, 3)
 #'   ),
 #'   var = data.frame(
+#'     row.names = paste0("var", 1:4),
 #'     n_cells = c(1, 2, 3, 4)
 #'   )
 #' )
 #'
 #' adata
 AnnData <- function(
-    obs_names = NULL,
-    var_names = NULL,
     X = NULL,
     obs = NULL,
     var = NULL,
@@ -72,8 +63,6 @@ AnnData <- function(
     varp = NULL,
     uns = NULL) {
   InMemoryAnnData$new(
-    obs_names = obs_names,
-    var_names = var_names,
     X = X,
     obs = obs,
     var = var,

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -13,6 +13,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
   active = list(
     #' @field X The X slot
     X = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_X, status=done
         read_h5ad_element(private$.h5obj, "X")
@@ -32,6 +33,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     #'   with with all elements having the dimensions consistent with
     #'   `obs` and `var`.
     layers = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_layers, status=done
         read_h5ad_element(private$.h5obj, "layers")
@@ -50,6 +52,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     #' @field obsm The obsm slot. Must be `NULL` or a named list with
     #'   with all elements having the same number of rows as `obs`.
     obsm = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_obsm, status=done
         read_h5ad_element(private$.h5obj, "obsm")
@@ -67,6 +70,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     #' @field varm The varm slot. Must be `NULL` or a named list with
     #'   with all elements having the same number of rows as `var`.
     varm = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_varm, status=done
         read_h5ad_element(private$.h5obj, "varm")
@@ -84,6 +88,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     #' @field obsp The obsp slot. Must be `NULL` or a named list with
     #'   with all elements having the same number of rows and columns as `obs`.
     obsp = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_obsp, status=done
         read_h5ad_element(private$.h5obj, "obsp")
@@ -102,6 +107,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     #' @field varp The varp slot. Must be `NULL` or a named list with
     #'   with all elements having the same number of rows and columns as `var`.
     varp = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_varp, status=done
         read_h5ad_element(private$.h5obj, "varp")
@@ -120,6 +126,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
 
     #' @field obs The obs slot
     obs = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_obs, status=done
         read_h5ad_element(private$.h5obj, "obs")
@@ -136,6 +143,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     },
     #' @field var The var slot
     var = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_var, status=done
         read_h5ad_element(private$.h5obj, "var")
@@ -151,6 +159,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     },
     #' @field obs_names Names of observations
     obs_names = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # TODO: fix efficiency
         # read_h5ad_data_frame_index(private$.h5obj, "obs")
@@ -166,6 +175,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     },
     #' @field var_names Names of variables
     var_names = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       # TODO: directly write to and read from /var/_index
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_var_names, status=done
@@ -182,6 +192,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     },
     #' @field uns The uns slot. Must be `NULL` or a named list.
     uns = function(value) {
+      if (!private$.h5obj$is_valid) stop("HDF5 file is closed")
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_uns, status=done
         read_h5ad_element(private$.h5obj, "uns")
@@ -369,7 +380,9 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
 
     #' @description Close the HDF5 file
     close = function() {
-      private$.h5obj$close_all()
+      if (private$.h5obj$is_valid) {
+        private$.h5obj$close_all()
+      }
     },
 
     #' @description Number of observations in the AnnData object

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -273,6 +273,35 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
         private$.close_on_finalize <- TRUE
         private$.n_obs <- length(obs_names)
         private$.n_vars <- length(var_names)
+
+
+        if (!is.null(obs)) {
+          self$obs <- obs
+        }
+        if (!is.null(var)) {
+          self$var <- var
+        }
+        if (!is.null(X)) {
+          self$X <- X
+        }
+        if (!is.null(layers)) {
+          self$layers <- layers
+        }
+        if (!is.null(obsm)) {
+          self$obsm <- obsm
+        }
+        if (!is.null(varm)) {
+          self$varm <- varm
+        }
+        if (!is.null(obsp)) {
+          self$obsp <- obsp
+        }
+        if (!is.null(varp)) {
+          self$varp <- varp
+        }
+        if (!is.null(uns)) {
+          self$uns <- uns
+        }
       } else {
         if (is.character(file)) {
           file <- hdf5r::H5File$new(file, mode = "r+") # allow changing the mode?
@@ -298,78 +327,46 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
         # Set the file path
         private$.h5obj <- file
         private$.close_on_finalize <- close_on_finalize
-      }
-      cat("init\n")
-      print(private$.h5obj)
-      # If obs or var names have been provided update those
-      if (!is.null(obs_names)) {
-        self$obs_names <- obs_names
-      }
-      cat("after obs names\n")
-      print(private$.h5obj)
-      
-      if (!is.null(var_names)) {
-        self$var_names <- var_names
-      }
-      cat("after var names\n")
-      print(private$.h5obj)
 
-      if (!is.null(obs)) {
-        self$obs <- obs
-      }
-      cat("after obs\n")
-      print(private$.h5obj)
-
-      if (!is.null(var)) {
-        self$var <- var
-      }
-      cat("after var\n")
-      print(private$.h5obj)
-
-      # Update remaining slots
-      if (!is.null(X)) {
-        self$X <- X
-      }
-      cat("after X\n")
-      print(private$.h5obj)
-
-      if (!is.null(layers)) {
-        self$layers <- layers
-      }
-
-      if (!is.null(obsm)) {
-        self$obsm <- obsm
-      }
-
-      if (!is.null(varm)) {
-        self$varm <- varm
-      }
-
-      if (!is.null(obsp)) {
-        self$obsp <- obsp
-      }
-
-      if (!is.null(varp)) {
-        self$varp <- varp
-      }
-
-      if (!is.null(uns)) {
-        self$uns <- uns
+        # assert other arguments are NULL
+        if (!is.null(obs_names)) {
+          stop("obs_names must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(var_names)) {
+          stop("var_names must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(X)) {
+          stop("X must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(layers)) {
+          stop("layers must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(obsm)) {
+          stop("obsm must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(varm)) {
+          stop("varm must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(obsp)) {
+          stop("obsp must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(varp)) {
+          stop("varp must be NULL when loading an existing .h5ad file")
+        }
+        if (!is.null(uns)) {
+          stop("uns must be NULL when loading an existing .h5ad file")
+        }
       }
     },
 
-    finalize = function() {
-      if (private$.close_on_finalize) {
-        ## first trigger the garbage collection, so that lost, but not yet collected objects are closed
-        gc()
-        ## need to flush before closing objects; the file itself is returned as an object,
-        ## so would close the file before we can flush
-        cat("Finalizing HDF5AnnData object, closing h5obj\n")
-        private$.h5obj$close_all()
-        private$.h5obj <- NULL
-      }
-      return(invisible(self))
-    },
+    # finalize = function() {
+    #   if (private$.close_on_finalize) {
+    #     ## first triFinalizing HDF5AnnData object, closing h5obj\n")
+    #     private$.h5obj$close_all()
+    #     private$.h5obj <- NULL
+    #   }
+    #   return(invisible(self))
+    # },
 
     #' @description Number of observations in the AnnData object
     n_obs = function() {

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -233,11 +233,13 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     #' @param compression The compression algorithm to use when writing the
     #'  HDF5 file. Can be one of `"none"`, `"gzip"` or `"lzf"`. Defaults to
     #' `"none"`.
-    #' @param mode The mode to open the HDF5 file. `a` creates a new file or opens
-    #'  an existing one for read/write. `r` opens an existing file for reading,
-    #'  `r+` opens an existing file for read/write. `w` creates a file, truncating
-    #'  any existing ones and `w-`/`x` are synonyms, creating a file and failing if
-    #'  it already exists.
+    #' @param mode The mode to open the HDF5 file.
+    #'
+    #'   * `a` creates a new file or opens an existing one for read/write.
+    #'   * `r` opens an existing file for reading.
+    #'   * `r+` opens an existing file for read/write.
+    #'   * `w` creates a file, truncating any existing ones.
+    #'   * `w-`/`x` are synonyms, creating a file and failing if it already exists.
     #'
     #' @details
     #' The constructor creates a new HDF5 AnnData interface object. This can
@@ -394,6 +396,13 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
 #' @param compression The compression algorithm to use when writing the
 #'  HDF5 file. Can be one of `"none"`, `"gzip"` or `"lzf"`. Defaults to
 #' `"none"`.
+#' @param mode The mode to open the HDF5 file.
+#'
+#'   * `a` creates a new file or opens an existing one for read/write.
+#'   * `r` opens an existing file for reading.
+#'   * `r+` opens an existing file for read/write.
+#'   * `w` creates a file, truncating any existing ones.
+#'   * `w-`/`x` are synonyms, creating a file and failing if it already exists.
 #'
 #' @return An HDF5AnnData object with the same data as the input AnnData
 #'   object.
@@ -413,11 +422,11 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
 #' to_HDF5AnnData(ad, "test.h5ad")
 #' # remove file
 #' file.remove("test.h5ad")
-to_HDF5AnnData <- function(
+to_HDF5AnnData <- function( # nolint
     adata,
     file,
     compression = c("none", "gzip", "lzf"),
-    mode = c("w-", "r", "r+", "a", "w", "x")) { # nolint
+    mode = c("w-", "r", "r+", "a", "w", "x")) {
   stopifnot(
     inherits(adata, "AbstractAnnData")
   )

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -367,10 +367,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
 
     #' @description Close the HDF5 file
     close = function() {
-      if (!is.null(private$.h5obj)) {
-        private$.h5obj$close_all()
-        private$.h5obj <- NULL
-      }
+      private$.h5obj$close_all()
     },
 
     #' @description Number of observations in the AnnData object

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -275,8 +275,11 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
         stop("The HDF5 interface requires the 'hdf5r' package to be installed")
       }
 
+      # check arguments
       compression <- match.arg(compression)
       mode <- match.arg(mode)
+
+      # store compression for later use
       private$.compression <- compression
 
       if (is.character(file) && !file.exists(file)) {

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -407,10 +407,8 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
 #'     A = matrix(5:1, 3L, 5L),
 #'     B = matrix(letters[1:5], 3L, 5L)
 #'   ),
-#'   obs = data.frame(cell = 1:3),
-#'   var = data.frame(gene = 1:5),
-#'   obs_names = LETTERS[1:3],
-#'   var_names = letters[1:5]
+#'   obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+#'   var = data.frame(row.names = letters[1:5], gene = 1:5),
 #' )
 #' to_HDF5AnnData(ad, "test.h5ad")
 #' # remove file

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -381,7 +381,7 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
     #' @description Close the HDF5 file
     close = function() {
       if (private$.h5obj$is_valid) {
-        private$.h5obj$close_all()
+        private$.h5obj$close()
       }
     },
 

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -35,8 +35,6 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData", # nolint
     .layers = NULL,
     .obs = NULL,
     .var = NULL,
-    .obs_names = NULL,
-    .var_names = NULL,
     .obsm = NULL,
     .varm = NULL,
     .obsp = NULL,
@@ -115,10 +113,10 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData", # nolint
     obs_names = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_obs_names, status=done
-        private$.obs_names
+        rownames(private$.obs)
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_obs_names, status=done
-        private$.obs_names <- private$.validate_obsvar_names(value, "obs")
+        rownames(private$.obs) <- private$.validate_obsvar_names(value, "obs")
         self
       }
     },
@@ -130,10 +128,10 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData", # nolint
     var_names = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_var_names, status=done
-        private$.var_names
+        rownames(private$.var)
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_var_names, status=done
-        private$.var_names <- private$.validate_obsvar_names(value, "var")
+        rownames(private$.var) <- private$.validate_obsvar_names(value, "var")
         self
       }
     },
@@ -257,9 +255,7 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData", # nolint
     #'   element is a sparse matrix where each dimension has length `n_vars`.
     #' @param uns The uns slot is used to store unstructured annotation.
     #'   It must be either `NULL` or a named list.
-    initialize = function(obs_names,
-                          var_names,
-                          X = NULL,
+    initialize = function(X = NULL,
                           obs = NULL,
                           var = NULL,
                           layers = NULL,
@@ -268,13 +264,29 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData", # nolint
                           obsp = NULL,
                           varp = NULL,
                           uns = NULL) {
-      # write obs and var first, because these are used by other validators
-      self$obs_names <- obs_names
-      self$var_names <- var_names
+      # initialise obs
+      if (is.null(obs)) {
+        # TODO: if X or layers is not null,
+        # derive the correct dimensions
+        obs <- data.frame()
+      }
+      if (!is.data.frame(obs)) {
+        stop("obs must be a data.frame")
+      }
+      private$.obs <- obs
+
+      # initialize var
+      if (is.null(var)) {
+        # TODO: if X or layers is not null,
+        # derive the correct dimensions
+        var <- data.frame()
+      }
+      if (!is.data.frame(var)) {
+        stop("var must be a data.frame")
+      }
+      private$.var <- var
 
       # write other slots later
-      self$obs <- obs
-      self$var <- var
       self$X <- X
       self$layers <- layers
       self$obsm <- obsm
@@ -319,8 +331,6 @@ to_InMemoryAnnData <- function(adata) { # nolint
     X = adata$X,
     obs = adata$obs,
     var = adata$var,
-    obs_names = adata$obs_names,
-    var_names = adata$var_names,
     layers = adata$layers,
     obsm = adata$obsm,
     varm = adata$varm,

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -7,26 +7,22 @@
 #'
 #' @examples
 #' ## complete example
-#' ad <- InMemoryAnnData$new(
+#' ad <- AnnData(
 #'   X = matrix(1:15, 3L, 5L),
 #'   layers = list(
 #'     A = matrix(5:1, 3L, 5L),
 #'     B = matrix(letters[1:5], 3L, 5L)
 #'   ),
-#'   obs = data.frame(cell = 1:3),
-#'   var = data.frame(gene = 1:5),
-#'   obs_names = LETTERS[1:3],
-#'   var_names = letters[1:5]
+#'   obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+#'   var = data.frame(row.names = letters[1:5], gene = 1:5)
 #' )
 #' ad
 #'
 #' ## minimum example
-#' # -> using `AnnData()` is synonymous to `InMemoryAnnData$new()`
-#' ad <- AnnData(
-#'   obs_names = letters[1:10],
-#'   var_names = LETTERS[1:5]
+#' AnnData(
+#'   obs = data.frame(row.names = letters[1:10]),
+#'   var = data.frame(row.names = LETTERS[1:5])
 #' )
-#' ad
 #' @export
 InMemoryAnnData <- R6::R6Class("InMemoryAnnData", # nolint
   inherit = AbstractAnnData,
@@ -317,10 +313,8 @@ InMemoryAnnData <- R6::R6Class("InMemoryAnnData", # nolint
 #'     A = matrix(5:1, 3L, 5L),
 #'     B = matrix(letters[1:5], 3L, 5L)
 #'   ),
-#'   obs = data.frame(cell = 1:3),
-#'   var = data.frame(gene = 1:5),
-#'   obs_names = LETTERS[1:3],
-#'   var_names = letters[1:5]
+#'   obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+#'   var = data.frame(row.names = letters[1:5], gene = 1:5)
 #' )
 #' to_InMemoryAnnData(ad)
 to_InMemoryAnnData <- function(adata) { # nolint

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -12,10 +12,8 @@
 #' @examples
 #' ad <- AnnData(
 #'   X = matrix(1:5, 3L, 5L),
-#'   obs = data.frame(cell = 1:3),
-#'   obs_names = letters[1:3],
-#'   var = data.frame(gene = 1:5),
-#'   var_names = letters[1:5]
+#'   obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+#'   var = data.frame(row.names = letters[1:5], gene = 1:5)
 #' )
 #' to_Seurat(ad)
 # TODO: Add parameters to choose which how X and layers are translated into counts, data and scaled.data
@@ -145,31 +143,23 @@ from_Seurat <- function(seurat_obj, output_class = c("InMemoryAnnData", "HDF5Ann
     }
   }
 
-  # get obs_names
-  # trackstatus: class=Seurat, feature=set_obs_names, status=done
-  obs_names <- colnames(seurat_obj)
-
   # get obs
+  # trackstatus: class=Seurat, feature=set_obs_names, status=done
   # trackstatus: class=Seurat, feature=set_obs, status=done
   obs <- seurat_obj@meta.data
-  rownames(obs) <- NULL
-
-  # construct var_names
-  # trackstatus: class=Seurat, feature=set_var_names, status=done
-  var_names <- rownames(seurat_obj@assays[[assay_name]])
+  rownames(obs) <- colnames(seurat_obj) # TODO: this is probably not needed
 
   # construct var
+  # trackstatus: class=Seurat, feature=set_var_names, status=done
   # trackstatus: class=Seurat, feature=set_var, status=done
   var <- seurat_obj@assays[[assay_name]]@meta.features
-  rownames(var) <- NULL
+  rownames(var) <- rownames(seurat_obj@assays[[assay_name]]) # TODO: this is probably not needed
 
   # use generator to create new AnnData object
   generator <- get_anndata_constructor(output_class)
   ad <- generator$new(
     obs = obs,
     var = var,
-    obs_names = obs_names,
-    var_names = var_names,
     ...
   )
 

--- a/R/SingleCellExperiment.R
+++ b/R/SingleCellExperiment.R
@@ -131,7 +131,7 @@ from_SingleCellExperiment <- function(sce, output_class = c("InMemory", "HDF5Ann
   var <- as.data.frame(
     SummarizedExperiment::rowData(sce)
   )
-  
+
   # trackstatus: class=SingleCellExperiment, feature=set_X, status=done
   # trackstatus: class=SingleCellExperiment, feature=set_layers, status=done
   x_and_layers <- lapply(

--- a/R/SingleCellExperiment.R
+++ b/R/SingleCellExperiment.R
@@ -16,15 +16,13 @@
 #'   library(SingleCellExperiment)
 #' }
 #' ad <- AnnData(
-#'   X = matrix(1:15, 3L, 5L),
+#'   X = matrix(1:5, 3L, 5L),
 #'   layers = list(
-#'     A = matrix(15:1, 3L, 5L),
-#'     B = matrix(letters[1:15], 3L, 5L)
+#'     A = matrix(5:1, 3L, 5L),
+#'     B = matrix(letters[1:5], 3L, 5L)
 #'   ),
-#'   obs = data.frame(cell = 1:3),
-#'   var = data.frame(gene = 1:5),
-#'   obs_names = LETTERS[1:3],
-#'   var_names = letters[1:5]
+#'   obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+#'   var = data.frame(row.names = letters[1:5], gene = 1:5)
 #' )
 #'
 #' ## construct a SingleCellExperiment from an AnnData object

--- a/R/SingleCellExperiment.R
+++ b/R/SingleCellExperiment.R
@@ -121,31 +121,17 @@ from_SingleCellExperiment <- function(sce, output_class = c("InMemory", "HDF5Ann
   generator <- get_anndata_constructor(output_class)
 
   # trackstatus: class=SingleCellExperiment, feature=set_obs, status=done
+  # trackstatus: class=SingleCellExperiment, feature=set_obs_names, status=done
   obs <- as.data.frame(
     SummarizedExperiment::colData(sce)
   )
-  rownames(obs) <- NULL
 
   # trackstatus: class=SingleCellExperiment, feature=set_var, status=done
+  # trackstatus: class=SingleCellExperiment, feature=set_var_names, status=done
   var <- as.data.frame(
     SummarizedExperiment::rowData(sce)
   )
-  rownames(var) <- NULL
-
-  # trackstatus: class=SingleCellExperiment, feature=set_obs_names, status=done
-  obs_names <- colnames(sce)
-  if (is.null(obs_names)) {
-    warning(wrap_message("colnames(sce) should not be NULL"))
-    obs_names <- as.character(seq_len(nrow(obs)))
-  }
-
-  # trackstatus: class=SingleCellExperiment, feature=set_var_names, status=done
-  var_names <- rownames(sce)
-  if (is.null(var_names)) {
-    warning(wrap_message("rownames(sce) should not be NULL"))
-    var_names <- as.character(seq_len(nrow(var)))
-  }
-
+  
   # trackstatus: class=SingleCellExperiment, feature=set_X, status=done
   # trackstatus: class=SingleCellExperiment, feature=set_layers, status=done
   x_and_layers <- lapply(
@@ -178,8 +164,6 @@ from_SingleCellExperiment <- function(sce, output_class = c("InMemory", "HDF5Ann
     X = x,
     obs = obs,
     var = var,
-    obs_names = obs_names,
-    var_names = var_names,
     layers = layers,
     ...
   )

--- a/R/SingleCellExperiment.R
+++ b/R/SingleCellExperiment.R
@@ -110,7 +110,11 @@ to_SingleCellExperiment <- function(object) { # nolint
 #' from_SingleCellExperiment(sce, "InMemory")
 #'
 #' @export
-from_SingleCellExperiment <- function(sce, output_class = c("InMemory", "HDF5AnnData"), ...) { # nolint
+from_SingleCellExperiment <- function( # nolint
+  sce,
+  output_class = c("InMemory", "HDF5AnnData"),
+  ...
+) {
   stopifnot(
     inherits(sce, "SingleCellExperiment")
   )

--- a/R/generate_dataset.R
+++ b/R/generate_dataset.R
@@ -170,9 +170,11 @@ generate_dataset <- function(
 
   # generate obs_names
   obs_names <- paste0("cell", seq_len(n_obs))
+  rownames(obs) <- obs_names
 
   # generate var_names
   var_names <- paste0("gene", seq_len(n_vars))
+  rownames(var) <- var_names
 
   # generate obsm
   obsm <- lapply(obsm_types, function(obsm_type) {
@@ -235,11 +237,9 @@ generate_dataset <- function(
   list(
     X = X,
     obs = obs,
-    obs_names = obs_names,
     obsm = obsm,
     obsp = obsp,
     var = var,
-    var_names = var_names,
     varm = varm,
     varp = varp,
     layers = layers,
@@ -333,11 +333,9 @@ generate_dataset <- function(
     obs = dataset_list$obs,
     obsm = dataset_list$obsm,
     obsp = dataset_list$obsp,
-    obs_names = dataset_list$obs_names,
     var = dataset_list$var,
     varm = dataset_list$varm,
     varp = dataset_list$varp,
-    var_names = dataset_list$var_names,
     layers = dataset_list$layers,
     uns = dataset_list$uns
   )

--- a/R/read_h5ad.R
+++ b/R/read_h5ad.R
@@ -5,6 +5,14 @@
 #' @param path Path to the H5AD file to read
 #' @param to The type of object to return. Must be one of: "InMemoryAnnData",
 #'   "HDF5AnnData", "SingleCellExperiment", "Seurat"
+#' @param mode The mode to open the HDF5 file.
+#'
+#'   * `a` creates a new file or opens an existing one for read/write.
+#'   * `r` opens an existing file for reading.
+#'   * `r+` opens an existing file for read/write.
+#'   * `w` creates a file, truncating any existing ones.
+#'   * `w-`/`x` are synonyms, creating a file and failing if it already exists.
+#'
 #' @param ... Extra arguments provided to [to_SingleCellExperiment()] or
 #'   [to_Seurat()]
 #'
@@ -26,10 +34,12 @@
 read_h5ad <- function(
     path,
     to = c("InMemoryAnnData", "HDF5AnnData", "SingleCellExperiment", "Seurat"),
+    mode = c("r", "r+", "a", "w", "w-", "x"),
     ...) {
   to <- match.arg(to)
+  mode <- match.arg(mode)
 
-  adata <- HDF5AnnData$new(path)
+  adata <- HDF5AnnData$new(path, mode = mode)
 
   fun <- switch(to,
     "SingleCellExperiment" = to_SingleCellExperiment,

--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -203,7 +203,6 @@ read_h5ad_rec_array <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
 
   as.list(file[[name]]$read())
-  # rhdf5::h5read(file, name, compoundAsDataFrame = FALSE)
 }
 
 #' Read H5AD nullable boolean
@@ -347,14 +346,7 @@ read_h5ad_string_scalar <- function(file, name, version = "0.2.0") {
 #' @noRd
 read_h5ad_numeric_scalar <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
-  scalar <- file[[name]]$read()
-
-  # # If the numeric vector is Boolean it gets read as a factor by {rhdf5}
-  # if (is.factor(scalar)) {
-  #   scalar <- as.logical(scalar)
-  # }
-
-  return(scalar)
+  file[[name]]$read()
 }
 
 #' Read H5AD mapping

--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -9,19 +9,24 @@
 #'
 #' @noRd
 read_h5ad_encoding <- function(file, name) {
-  attrs <- rhdf5::h5readAttributes(file, name)
-
-  if (!all(c("encoding-type", "encoding-version") %in% names(attrs))) {
-    path <- if (is.character(file)) file else rhdf5::H5Fget_name(file)
-    stop(
-      "Encoding attributes not found for element '", name, "' ",
-      "in '", path, "'"
-    )
+  if (!is.null(name)) {
+    file <- file[[name]]
   }
 
-  list(
-    type = attrs[["encoding-type"]],
-    version = attrs[["encoding-version"]]
+  tryCatch(
+    {
+      list(
+        type = hdf5r::h5attr(file, "encoding-type"),
+        version = hdf5r::h5attr(file, "encoding-version")
+      )
+    },
+    error = function(e) {
+      path <- if (is.character(file)) file else file$get_filename()
+      stop(
+        "Encoding attributes not found for element '", name, "' ",
+        "in '", path, "'"
+      )
+    }
   )
 }
 
@@ -101,14 +106,14 @@ read_h5ad_element <- function(file, name, type = NULL, version = NULL, stop_on_e
 #' @noRd
 read_h5ad_dense_array <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
-  # TODO: ideally, native = TRUE should take care of the row order and column order,
-  # but it doesn't
-  darr <- t(rhdf5::h5read(file, name))
-  # If the dense array is a 1D matrix, convert to vector
-  if (any(dim(darr) == 1)) {
-    darr <- as.vector(darr)
+  
+  data <- file[[name]]$read()
+
+  # transpose the matrix if need be
+  if (is.matrix(data)) {
+    data <- t(data)
   }
-  darr
+  data
 }
 
 read_h5ad_csr_matrix <- function(file, name, version) {
@@ -147,10 +152,10 @@ read_h5ad_sparse_array <- function(file, name, version = "0.1.0",
   version <- match.arg(version)
   type <- match.arg(type)
 
-  data <- as.vector(rhdf5::h5read(file, paste0(name, "/data")))
-  indices <- as.vector(rhdf5::h5read(file, paste0(name, "/indices")))
-  indptr <- as.vector(rhdf5::h5read(file, paste0(name, "/indptr")))
-  shape <- as.vector(rhdf5::h5readAttributes(file, name)$shape)
+  data <- as.vector(file[[paste0(name, "/data")]]$read())
+  indices <- as.vector(file[[paste0(name, "/indices")]]$read())
+  indptr <- as.vector(file[[paste0(name, "/indptr")]]$read())
+  shape <- as.vector(hdf5r::h5attr(file[[name]], "shape"))
 
   if (type == "csc_matrix") {
     mtx <- Matrix::sparseMatrix(
@@ -197,7 +202,8 @@ read_h5ad_sparse_array <- function(file, name, version = "0.1.0",
 read_h5ad_rec_array <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
 
-  rhdf5::h5read(file, name, compoundAsDataFrame = FALSE)
+  as.list(file[[name]]$read())
+  # rhdf5::h5read(file, name, compoundAsDataFrame = FALSE)
 }
 
 #' Read H5AD nullable boolean
@@ -244,19 +250,15 @@ read_h5ad_nullable_integer <- function(file, name, version = "0.1.0") {
 read_h5ad_nullable <- function(file, name, version = "0.1.0") {
   version <- match.arg(version)
 
-  element <- rhdf5::h5read(file, name)
+  grp <- file[[name]]
 
-  # Some versions of rhdf5 automatically apply mask, in which case
-  # there is no 'mask' element
-  if (!is.null(names(element))) {
-    # Get mask and convert to Boolean
-    mask <- as.logical(element[["mask"]])
-    # Get values and set missing
-    element <- as.vector(element[["values"]])
-    element[mask] <- NA
-  }
+  data <- grp[["values"]]$read()
 
-  return(element)
+  mask <- grp[["mask"]]$read()
+
+  data[mask] <- NA
+
+  data
 }
 
 #' Read H5AD string array
@@ -273,7 +275,7 @@ read_h5ad_nullable <- function(file, name, version = "0.1.0") {
 read_h5ad_string_array <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
   # reads in transposed
-  string_array <- rhdf5::h5read(file, name)
+  string_array <- file[[name]]$read()
   if (is.matrix(string_array)) {
     string_array <- t(string_array)
   }
@@ -300,33 +302,18 @@ read_h5ad_string_array <- function(file, name, version = "0.2.0") {
 read_h5ad_categorical <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
 
-  element <- rhdf5::h5read(file, name)
+  element <- file[[name]]
 
   # Get codes and convert to 1-based indexing
-  codes <- element[["codes"]] + 1
-
-  if (!length(dim(codes)) == 1) {
-    stop("There is currently no support for multidimensional categorical arrays")
-  }
+  codes <- element[["codes"]]$read() + 1
 
   # Set missing values
   codes[codes == 0] <- NA
 
-  levels <- element[["categories"]]
+  levels <- element[["categories"]]$read()
 
-  attributes <- rhdf5::h5readAttributes(file, name)
+  attributes <- hdf5r::h5attributes(file[[name]])
   ordered <- attributes[["ordered"]]
-  if (is.null(ordered) || is.na(ordered)) {
-    # This version of {rhdf5} doesn't yet support ENUM type attributes so we
-    # can't tell if the categorical should be ordered,
-    # see https://github.com/grimbough/rhdf5/issues/125
-    warning(
-      "Unable to determine if categorical '", name,
-      "' is ordered, assuming it isn't"
-    )
-
-    ordered <- FALSE
-  }
 
   factor(codes, labels = levels, ordered = ordered)
 }
@@ -344,7 +331,7 @@ read_h5ad_categorical <- function(file, name, version = "0.2.0") {
 #' @noRd
 read_h5ad_string_scalar <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
-  rhdf5::h5read(file, name)
+  file[[name]]$read()
 }
 
 #' Read H5AD numeric scalar
@@ -360,12 +347,12 @@ read_h5ad_string_scalar <- function(file, name, version = "0.2.0") {
 #' @noRd
 read_h5ad_numeric_scalar <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
-  scalar <- rhdf5::h5read(file, name)
+  scalar <- file[[name]]$read()
 
-  # If the numeric vector is Boolean it gets read as a factor by {rhdf5}
-  if (is.factor(scalar)) {
-    scalar <- as.logical(scalar)
-  }
+  # # If the numeric vector is Boolean it gets read as a factor by {rhdf5}
+  # if (is.factor(scalar)) {
+  #   scalar <- as.logical(scalar)
+  # }
 
   return(scalar)
 }
@@ -383,10 +370,8 @@ read_h5ad_numeric_scalar <- function(file, name, version = "0.2.0") {
 #' @noRd
 read_h5ad_mapping <- function(file, name, version = "0.1.0") {
   version <- match.arg(version)
-  groupname <- paste0("/", name)
 
-  file_structure <- rhdf5::h5ls(file, recursive = TRUE)
-  columns <- file_structure[file_structure$group == groupname, "name"]
+  columns <- file[[name]]$ls()$name
 
   read_h5ad_collection(file, name, columns)
 }
@@ -413,30 +398,33 @@ read_h5ad_data_frame <- function(file, name, include_index = FALSE,
                                  version = "0.2.0") {
   version <- match.arg(version)
 
-  attributes <- rhdf5::h5readAttributes(file, name)
-  index_name <- attributes$`_index`
-  column_order <- attributes$`column-order`
+  index_name <- hdf5r::h5attr(file[[name]], "_index")
+  column_order <- tryCatch(
+    {
+      hdf5r::h5attr(file[[name]], "column-order")
+    },
+    error = function(e) {
+      c()
+    }
+  )
 
   columns <- read_h5ad_collection(file, name, column_order)
 
-  if (length(columns) == 0) {
-    index <- read_h5ad_data_frame_index(file, name)
-    df <- data.frame(row.names = seq_along(index))
-  } else {
-    df <- data.frame(columns)
-  }
+  # convert data to dataframe
+  df <- data.frame(
+    columns,
+    check.names = FALSE,
+    fix.empty.names = FALSE
+  )
 
+  # add index to data frame if requested
   if (isTRUE(include_index)) {
-    index <- read_h5ad_data_frame_index(file, name)
-    df <- cbind(index, df)
-
-    # The default index name is not allowed as a column name so adjust it
-    if (index_name == "_index") {
-      index_name <- ".index"
-      colnames(df)[1] <- index_name
-    }
-
-    attr(df, "_index") <- index_name # nolint
+    df <- cbind(
+      read_h5ad_data_frame_index(file, name),
+      df
+    )
+    names(df)[[1]] <- index_name
+    attr(df, "_index") <- index_name
   }
 
   df
@@ -456,27 +444,26 @@ read_h5ad_data_frame <- function(file, name, include_index = FALSE,
 read_h5ad_data_frame_index <- function(file, name, version = "0.2.0") {
   version <- match.arg(version)
 
-  attributes <- rhdf5::h5readAttributes(file, name)
-  index_name <- attributes$`_index`
+  index_name <- hdf5r::h5attr(file[[name]], "_index")
 
-  read_h5ad_element(file, file.path(name, index_name))
+  read_h5ad_element(file, paste0(name, "/", index_name))
 }
 
 #' Read multiple H5AD datatypes
 #'
 #' @param file Path to a H5AD file or an open H5AD handle
 #' @param name Name of the element within the H5AD file
-#' @param column_order Vector of item names (in order)
+#' @param item_names Vector of item names (in order)
 #'
 #' @return a named list
 #'
 #' @noRd
-read_h5ad_collection <- function(file, name, column_order) {
+read_h5ad_collection <- function(file, name, item_names) {
   columns <- list()
-  for (col_name in column_order) {
-    new_name <- paste0(name, "/", col_name)
+  for (item_name in item_names) {
+    new_name <- paste0(name, "/", item_name)
     encoding <- read_h5ad_encoding(file, new_name)
-    columns[[col_name]] <- read_h5ad_element(
+    columns[[item_name]] <- read_h5ad_element(
       file = file,
       name = new_name,
       type = encoding$type,

--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -399,14 +399,7 @@ read_h5ad_data_frame <- function(file, name, include_index = FALSE,
   version <- match.arg(version)
 
   index_name <- hdf5r::h5attr(file[[name]], "_index")
-  column_order <- tryCatch(
-    {
-      hdf5r::h5attr(file[[name]], "column-order")
-    },
-    error = function(e) {
-      c()
-    }
-  )
+  column_order <- hdf5r::h5attr(file[[name]], "column-order")
 
   columns <- read_h5ad_collection(file, name, column_order)
 

--- a/R/write_h5ad.R
+++ b/R/write_h5ad.R
@@ -8,6 +8,12 @@
 #' @param compression The compression algorithm to use when writing the
 #'  HDF5 file. Can be one of `"none"`, `"gzip"` or `"lzf"`. Defaults to
 #' `"none"`.
+#' @param mode The mode to open the HDF5 file.
+#'
+#'   * `a` creates a new file or opens an existing one for read/write.
+#'   * `r+` opens an existing file for read/write.
+#'   * `w` creates a file, truncating any existing ones
+#'   * `w-`/`x` are synonyms creating a file and failing if it already exists.
 #'
 #' @return `path` invisibly
 #' @export
@@ -70,26 +76,35 @@ write_h5ad <- function(
     path,
     compression = c("none", "gzip", "lzf"),
     mode = c("w-", "r", "r+", "a", "w", "x")) {
-  if (inherits(object, "SingleCellExperiment")) {
-    from_SingleCellExperiment(
-      object,
-      output_class = "HDF5AnnData",
-      file = path,
-      compression = compression
-    )
-  } else if (inherits(object, "Seurat")) {
-    from_Seurat(
-      object,
-      output_class = "HDF5AnnData",
-      file = path,
-      compression = compression
-    )
-  } else if (inherits(object, "AbstractAnnData")) {
-    mode <- match.arg(mode)
-    to_HDF5AnnData(object, path, compression = compression, mode = mode)
-  } else {
-    stop("Unable to write object of class: ", class(object))
-  }
+  adata <-
+    if (inherits(object, "SingleCellExperiment")) {
+      from_SingleCellExperiment(
+        object,
+        output_class = "HDF5AnnData",
+        file = path,
+        compression = compression,
+        mode = mode
+      )
+    } else if (inherits(object, "Seurat")) {
+      from_Seurat(
+        object,
+        output_class = "HDF5AnnData",
+        file = path,
+        compression = compression,
+        mode = mode
+      )
+    } else if (inherits(object, "AbstractAnnData")) {
+      mode <- match.arg(mode)
+      to_HDF5AnnData(
+        object,
+        path,
+        compression = compression,
+        mode = mode
+      )
+    } else {
+      stop("Unable to write object of class: ", class(object))
+    }
+  adata$close()
 
   invisible(path)
 }

--- a/R/write_h5ad.R
+++ b/R/write_h5ad.R
@@ -76,6 +76,7 @@ write_h5ad <- function(
     path,
     compression = c("none", "gzip", "lzf"),
     mode = c("w-", "r", "r+", "a", "w", "x")) {
+  mode <- match.arg(mode)
   adata <-
     if (inherits(object, "SingleCellExperiment")) {
       from_SingleCellExperiment(
@@ -94,7 +95,6 @@ write_h5ad <- function(
         mode = mode
       )
     } else if (inherits(object, "AbstractAnnData")) {
-      mode <- match.arg(mode)
       to_HDF5AnnData(
         object,
         path,

--- a/R/write_h5ad.R
+++ b/R/write_h5ad.R
@@ -13,16 +13,14 @@
 #' @export
 #'
 #' @examples
-#' adata <- AnnData(
-#'   X = matrix(1:15, 3L, 5L),
+#' ad <- AnnData(
+#'   X = matrix(1:5, 3L, 5L),
 #'   layers = list(
-#'     A = matrix(15:1, 3L, 5L),
-#'     B = matrix(letters[1:15], 3L, 5L)
+#'     A = matrix(5:1, 3L, 5L),
+#'     B = matrix(letters[1:5], 3L, 5L)
 #'   ),
-#'   obs = data.frame(cell = 1:3),
-#'   var = data.frame(gene = 1:5),
-#'   obs_names = LETTERS[1:3],
-#'   var_names = letters[1:5]
+#'   obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+#'   var = data.frame(row.names = letters[1:5], gene = 1:5)
 #' )
 #' h5ad_file <- tempfile(fileext = ".h5ad")
 #' write_h5ad(adata, h5ad_file)

--- a/R/write_h5ad.R
+++ b/R/write_h5ad.R
@@ -67,7 +67,11 @@
 #'   # h5ad_file <- tempfile(fileext = ".h5ad")
 #'   # write_h5ad(obj, h5ad_file)
 #' }
-write_h5ad <- function(object, path, compression = c("none", "gzip", "lzf")) {
+write_h5ad <- function(
+    object,
+    path,
+    compression = c("none", "gzip", "lzf"),
+    mode = c("w-", "r", "r+", "a", "w", "x")) {
   if (inherits(object, "SingleCellExperiment")) {
     from_SingleCellExperiment(
       object,
@@ -83,7 +87,8 @@ write_h5ad <- function(object, path, compression = c("none", "gzip", "lzf")) {
       compression = compression
     )
   } else if (inherits(object, "AbstractAnnData")) {
-    to_HDF5AnnData(object, path, compression = compression)
+    mode <- match.arg(mode)
+    to_HDF5AnnData(object, path, compression = compression, mode = mode)
   } else {
     stop("Unable to write object of class: ", class(object))
   }

--- a/R/write_h5ad.R
+++ b/R/write_h5ad.R
@@ -105,6 +105,8 @@ write_h5ad <- function(
       stop("Unable to write object of class: ", class(object))
     }
   adata$close()
+  rm(adata)
+  gc()
 
   invisible(path)
 }

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -16,9 +16,14 @@
 #' `write_h5ad_element()` should always be used instead of any of the specific
 #' writing functions as it contains additional boilerplate to make sure
 #' elements are written correctly.
-write_h5ad_element <- function(value, file, name,
-                               compression = c("none", "gzip", "lzf"),
-                               stop_on_error = FALSE, ...) { # nolint
+# nolint start cyclocomp_linter
+write_h5ad_element <- function(
+    value,
+    file,
+    name,
+    compression = c("none", "gzip", "lzf"),
+    stop_on_error = FALSE,
+    ...) {
   compression <- match.arg(compression)
 
   # Delete the path if it already exists
@@ -68,7 +73,11 @@ write_h5ad_element <- function(value, file, name,
   tryCatch(
     {
       write_fun(
-        value = value, file = file, name = name, compression = compression, ...
+        value = value,
+        file = file,
+        name = name,
+        compression = compression,
+        ...
       )
     },
     error = function(e) {
@@ -85,6 +94,7 @@ write_h5ad_element <- function(value, file, name,
     }
   )
 }
+# nolint end cyclocomp_linter
 
 #' Write H5AD attributes
 #'
@@ -124,7 +134,8 @@ write_h5ad_attributes <- function(file, name, attributes, is_scalar = TRUE) {
     attr_value <- attributes[[attr_name]]
     scalar_value <- attr_name %in% is_scalar
     rhdf5::h5writeAttribute(
-      attr_value, h5obj, attr_name, asScalar = scalar_value
+      attr_value, h5obj, attr_name,
+      asScalar = scalar_value
     ) # nolint
   }
 }
@@ -215,7 +226,8 @@ write_h5ad_sparse_array <- function(value, file, name, compression, version = "0
 
   # Write shape attribute
   write_h5ad_attributes(
-    file, name, list("shape" = dim(value)), is_scalar = FALSE
+    file, name, list("shape" = dim(value)),
+    is_scalar = FALSE
   )
 }
 
@@ -447,7 +459,8 @@ write_h5ad_data_frame <- function(value, file, name, compression, index = NULL,
   }
 
   write_h5ad_attributes(
-    file, name, list("column-order" = col_order), is_scalar = FALSE
+    file, name, list("column-order" = col_order),
+    is_scalar = FALSE
   )
 }
 

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -107,7 +107,7 @@ write_h5ad_element <- function(
 #' @param attributes Named list of attributes to write
 #' @param is_scalar Whether to write attributes as scalar values. Can be `TRUE`
 #' to write all attributes as scalars, `FALSE` to write no attributes as
-#' scalars or a vector of the names of `attributes` that should be written.
+#' scalars, or a vector of the names of `attributes` that should be written.
 write_h5ad_attributes <- function(file, name, attributes, is_scalar = TRUE) {
   h5file <- rhdf5::H5Fopen(file)
   on.exit(rhdf5::H5Fclose(h5file))
@@ -132,11 +132,12 @@ write_h5ad_attributes <- function(file, name, attributes, is_scalar = TRUE) {
 
   for (attr_name in names(attributes)) {
     attr_value <- attributes[[attr_name]]
-    scalar_value <- attr_name %in% is_scalar
     rhdf5::h5writeAttribute(
-      attr_value, h5obj, attr_name,
-      asScalar = scalar_value
-    ) # nolint
+      attr = attr_value,
+      h5obj = h5obj,
+      name = attr_name,
+      asScalar = attr_name %in% is_scalar
+    )
   }
 }
 

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -278,11 +278,25 @@ write_h5ad_string_array <- function(value, file, name, compression, version = "0
 #' @param version Encoding version of the element to write
 write_h5ad_categorical <- function(value, file, name, compression, version = "0.2.0") {
   rhdf5::h5createGroup(file, name)
-  hdf5_write_compressed(file, paste0(name, "/categories"), as.integer(levels(value)), compression)
-  hdf5_write_compressed(file, paste0(name, "/codes"), as.integer(value), compression)
-  hdf5_write_compressed(file, paste0(name, "/ordered"), is.ordered(value), compression)
+  
+  categories <- levels(value)
+  codes <- as.integer(value)
+  codes[is.na(codes)] <- 0 # Set NA values to 0
+  codes <- codes - 1 # Make 0-indexed
+  
+  hdf5_write_compressed(file, paste0(name, "/categories"), categories, compression)
+  hdf5_write_compressed(file, paste0(name, "/codes"), codes, compression)
 
   write_h5ad_encoding(file, name, "categorical", version)
+  
+  # Write ordered attribute
+  h5file <- rhdf5::H5Fopen(file)
+  on.exit(rhdf5::H5Fclose(h5file))
+  
+  h5obj <- rhdf5::H5Gopen(h5file, name)
+  on.exit(rhdf5::H5Gclose(h5obj), add = TRUE)
+  
+  rhdf5::h5writeAttribute(is.ordered(value), h5obj, "ordered", asScalar = TRUE)
 }
 
 #' Write H5AD string scalar

--- a/man/AnnData.Rd
+++ b/man/AnnData.Rd
@@ -5,8 +5,6 @@
 \title{An in-memory AnnData object}
 \usage{
 AnnData(
-  obs_names = NULL,
-  var_names = NULL,
   X = NULL,
   obs = NULL,
   var = NULL,
@@ -19,16 +17,6 @@ AnnData(
 )
 }
 \arguments{
-\item{obs_names}{A vector of unique identifiers
-used to identify each row of \code{obs} and to act as an index into the
-observation dimension of the AnnData object. The length of \code{obs_names}
-defines the observation dimension of the AnnData object.}
-
-\item{var_names}{A vector of unique identifiers used to identify each row
-of \code{var} and to act as an index into the variable dimension of the
-AnnData object. The length of \code{var_names} defines the variable
-dimension of the AnnData object.}
-
 \item{X}{Either \code{NULL} or a observation × variable matrix with
 dimensions consistent with \code{obs} and \code{var}.}
 
@@ -62,6 +50,8 @@ element is a sparse matrix where each dimension has length \code{n_vars}.}
 
 \item{uns}{The uns slot is used to store unstructured annotation. It must
 be either \code{NULL} or a named list.}
+
+\item{AnnData}{object.}
 }
 \description{
 This class is used to represent an AnnData object in memory.
@@ -73,14 +63,14 @@ To read an AnnData file from disk, use \code{\link[=read_h5ad]{read_h5ad()}} ins
 }
 \examples{
 adata <- AnnData(
-  obs_names = paste0("obs", 1:3),
-  var_names = paste0("var", 1:4),
   X = matrix(1:12, nrow = 3, ncol = 4),
   obs = data.frame(
+    row.names = paste0("obs", 1:3),
     n_counts = c(1, 2, 3),
     n_cells = c(1, 2, 3)
   ),
   var = data.frame(
+    row.names = paste0("var", 1:4),
     n_cells = c(1, 2, 3, 4)
   )
 )

--- a/man/HDF5AnnData.Rd
+++ b/man/HDF5AnnData.Rd
@@ -133,11 +133,14 @@ element is a sparse matrix where each dimension has length \code{n_vars}.}
 \item{\code{uns}}{The uns slot is used to store unstructured annotation. It must
 be either \code{NULL} or a named list.}
 
-\item{\code{mode}}{The mode to open the HDF5 file. \code{a} creates a new file or opens
-an existing one for read/write. \code{r} opens an existing file for reading,
-\verb{r+} opens an existing file for read/write. \code{w} creates a file, truncating
-any existing ones and \verb{w-}/\code{x} are synonyms, creating a file and failing if
-it already exists.}
+\item{\code{mode}}{The mode to open the HDF5 file.
+\itemize{
+\item \code{a} creates a new file or opens an existing one for read/write.
+\item \code{r} opens an existing file for reading.
+\item \verb{r+} opens an existing file for read/write.
+\item \code{w} creates a file, truncating any existing ones.
+\item \verb{w-}/\code{x} are synonyms, creating a file and failing if it already exists.
+}}
 
 \item{\code{compression}}{The compression algorithm to use when writing the
 HDF5 file. Can be one of \code{"none"}, \code{"gzip"} or \code{"lzf"}. Defaults to

--- a/man/HDF5AnnData.Rd
+++ b/man/HDF5AnnData.Rd
@@ -46,9 +46,10 @@ with all elements having the same number of rows and columns as \code{var}.}
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-HDF5AnnData-new}{\code{HDF5AnnData$new()}}
+\item \href{#method-HDF5AnnData-finalize}{\code{HDF5AnnData$finalize()}}
+\item \href{#method-HDF5AnnData-close}{\code{HDF5AnnData$close()}}
 \item \href{#method-HDF5AnnData-n_obs}{\code{HDF5AnnData$n_obs()}}
 \item \href{#method-HDF5AnnData-n_vars}{\code{HDF5AnnData$n_vars()}}
-\item \href{#method-HDF5AnnData-clone}{\code{HDF5AnnData$clone()}}
 }
 }
 \if{html}{\out{
@@ -78,8 +79,6 @@ HDF5AnnData constructor
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{HDF5AnnData$new(
   file,
-  obs_names = NULL,
-  var_names = NULL,
   X = NULL,
   obs = NULL,
   var = NULL,
@@ -89,6 +88,7 @@ HDF5AnnData constructor
   obsp = NULL,
   varp = NULL,
   uns = NULL,
+  mode = c("r", "r+", "a", "w", "w-", "x"),
   compression = c("none", "gzip", "lzf")
 )}\if{html}{\out{</div>}}
 }
@@ -98,16 +98,6 @@ HDF5AnnData constructor
 \describe{
 \item{\code{file}}{The filename (character) of the \code{.h5ad} file. If this
 file does not exist yet, \code{obs_names} and \code{var_names} must be provided.}
-
-\item{\code{obs_names}}{A vector of unique identifiers
-used to identify each row of \code{obs} and to act as an index into the
-observation dimension of the AnnData object. The length of \code{obs_names}
-defines the observation dimension of the AnnData object.}
-
-\item{\code{var_names}}{A vector of unique identifiers used to identify each row
-of \code{var} and to act as an index into the variable dimension of the
-AnnData object. The length of \code{var_names} defines the variable
-dimension of the AnnData object.}
 
 \item{\code{X}}{Either \code{NULL} or a observation × variable matrix with
 dimensions consistent with \code{obs} and \code{var}.}
@@ -143,9 +133,25 @@ element is a sparse matrix where each dimension has length \code{n_vars}.}
 \item{\code{uns}}{The uns slot is used to store unstructured annotation. It must
 be either \code{NULL} or a named list.}
 
+\item{\code{mode}}{The mode to open the HDF5 file. \code{a} creates a new file or opens
+an existing one for read/write. \code{r} opens an existing file for reading,
+\verb{r+} opens an existing file for read/write. \code{w} creates a file, truncating
+any existing ones and \verb{w-}/\code{x} are synonyms, creating a file and failing if
+it already exists.}
+
 \item{\code{compression}}{The compression algorithm to use when writing the
 HDF5 file. Can be one of \code{"none"}, \code{"gzip"} or \code{"lzf"}. Defaults to
 \code{"none"}.}
+
+\item{\code{obs_names}}{A vector of unique identifiers
+used to identify each row of \code{obs} and to act as an index into the
+observation dimension of the AnnData object. The length of \code{obs_names}
+defines the observation dimension of the AnnData object.}
+
+\item{\code{var_names}}{A vector of unique identifiers used to identify each row
+of \code{var} and to act as an index into the variable dimension of the
+AnnData object. The length of \code{var_names} defines the variable
+dimension of the AnnData object.}
 }
 \if{html}{\out{</div>}}
 }
@@ -156,6 +162,26 @@ create a new one. To create a new file both \code{obs_names} and \code{var_names
 must be specified. In both cases, any additional slots provided will be
 set on the created object. This will cause data to be overwritten if the
 file already exists.
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-HDF5AnnData-finalize"></a>}}
+\if{latex}{\out{\hypertarget{method-HDF5AnnData-finalize}{}}}
+\subsection{Method \code{finalize()}}{
+Close the HDF5 file when the object is garbage collected
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HDF5AnnData$finalize()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-HDF5AnnData-close"></a>}}
+\if{latex}{\out{\hypertarget{method-HDF5AnnData-close}{}}}
+\subsection{Method \code{close()}}{
+Close the HDF5 file
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{HDF5AnnData$close()}\if{html}{\out{</div>}}
 }
 
 }
@@ -178,22 +204,5 @@ Number of variables in the AnnData object
 \if{html}{\out{<div class="r">}}\preformatted{HDF5AnnData$n_vars()}\if{html}{\out{</div>}}
 }
 
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-HDF5AnnData-clone"></a>}}
-\if{latex}{\out{\hypertarget{method-HDF5AnnData-clone}{}}}
-\subsection{Method \code{clone()}}{
-The objects of this class are cloneable with this method.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{HDF5AnnData$clone(deep = FALSE)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{deep}}{Whether to make a deep clone.}
-}
-\if{html}{\out{</div>}}
-}
 }
 }

--- a/man/InMemoryAnnData.Rd
+++ b/man/InMemoryAnnData.Rd
@@ -114,8 +114,6 @@ Creates a new instance of an in memory AnnData object.
 Inherits from AbstractAnnData.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{InMemoryAnnData$new(
-  obs_names,
-  var_names,
   X = NULL,
   obs = NULL,
   var = NULL,
@@ -131,18 +129,6 @@ Inherits from AbstractAnnData.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{obs_names}}{A vector of unique identifiers
-used to identify each row of \code{obs} and to act as an index into
-the observation dimension of the AnnData object. The length of
-the \code{obs_names} defines the observation dimension of the AnnData
-object.}
-
-\item{\code{var_names}}{A vector of unique identifers
-used to identify each row of \code{var} and to act as an index into
-the variable dimension of the AnnData object. The length of
-the \code{var_names} defines the variable dimension of the AnnData
-object.}
-
 \item{\code{X}}{Either \code{NULL} or a observation × variable matrix with
 dimensions consistent with \code{obs} and \code{var}.}
 
@@ -176,6 +162,18 @@ element is a sparse matrix where each dimension has length \code{n_vars}.}
 
 \item{\code{uns}}{The uns slot is used to store unstructured annotation.
 It must be either \code{NULL} or a named list.}
+
+\item{\code{obs_names}}{A vector of unique identifiers
+used to identify each row of \code{obs} and to act as an index into
+the observation dimension of the AnnData object. The length of
+the \code{obs_names} defines the observation dimension of the AnnData
+object.}
+
+\item{\code{var_names}}{A vector of unique identifers
+used to identify each row of \code{var} and to act as an index into
+the variable dimension of the AnnData object. The length of
+the \code{var_names} defines the variable dimension of the AnnData
+object.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/InMemoryAnnData.Rd
+++ b/man/InMemoryAnnData.Rd
@@ -8,26 +8,22 @@ Implementation of an in memory AnnData object.
 }
 \examples{
 ## complete example
-ad <- InMemoryAnnData$new(
+ad <- AnnData(
   X = matrix(1:15, 3L, 5L),
   layers = list(
     A = matrix(5:1, 3L, 5L),
     B = matrix(letters[1:5], 3L, 5L)
   ),
-  obs = data.frame(cell = 1:3),
-  var = data.frame(gene = 1:5),
-  obs_names = LETTERS[1:3],
-  var_names = letters[1:5]
+  obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+  var = data.frame(row.names = letters[1:5], gene = 1:5)
 )
 ad
 
 ## minimum example
-# -> using `AnnData()` is synonymous to `InMemoryAnnData$new()`
-ad <- AnnData(
-  obs_names = letters[1:10],
-  var_names = LETTERS[1:5]
+AnnData(
+  obs = data.frame(row.names = letters[1:10]),
+  var = data.frame(row.names = LETTERS[1:5])
 )
-ad
 }
 \section{Super class}{
 \code{\link[anndataR:AbstractAnnData]{anndataR::AbstractAnnData}} -> \code{InMemoryAnnData}

--- a/man/Seurat.Rd
+++ b/man/Seurat.Rd
@@ -39,10 +39,8 @@ Only one assay can be converted at a time.
 \examples{
 ad <- AnnData(
   X = matrix(1:5, 3L, 5L),
-  obs = data.frame(cell = 1:3),
-  obs_names = letters[1:3],
-  var = data.frame(gene = 1:5),
-  var_names = letters[1:5]
+  obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+  var = data.frame(row.names = letters[1:5], gene = 1:5)
 )
 to_Seurat(ad)
 }

--- a/man/SingleCellExperiment.Rd
+++ b/man/SingleCellExperiment.Rd
@@ -44,15 +44,13 @@ if (interactive()) {
   library(SingleCellExperiment)
 }
 ad <- AnnData(
-  X = matrix(1:15, 3L, 5L),
+  X = matrix(1:5, 3L, 5L),
   layers = list(
-    A = matrix(15:1, 3L, 5L),
-    B = matrix(letters[1:15], 3L, 5L)
+    A = matrix(5:1, 3L, 5L),
+    B = matrix(letters[1:5], 3L, 5L)
   ),
-  obs = data.frame(cell = 1:3),
-  var = data.frame(gene = 1:5),
-  obs_names = LETTERS[1:3],
-  var_names = letters[1:5]
+  obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+  var = data.frame(row.names = letters[1:5], gene = 1:5)
 )
 
 ## construct a SingleCellExperiment from an AnnData object

--- a/man/read_h5ad.Rd
+++ b/man/read_h5ad.Rd
@@ -7,6 +7,7 @@
 read_h5ad(
   path,
   to = c("InMemoryAnnData", "HDF5AnnData", "SingleCellExperiment", "Seurat"),
+  mode = c("r", "r+", "a", "w", "w-", "x"),
   ...
 )
 }
@@ -15,6 +16,15 @@ read_h5ad(
 
 \item{to}{The type of object to return. Must be one of: "InMemoryAnnData",
 "HDF5AnnData", "SingleCellExperiment", "Seurat"}
+
+\item{mode}{The mode to open the HDF5 file.
+\itemize{
+\item \code{a} creates a new file or opens an existing one for read/write.
+\item \code{r} opens an existing file for reading.
+\item \verb{r+} opens an existing file for read/write.
+\item \code{w} creates a file, truncating any existing ones.
+\item \verb{w-}/\code{x} are synonyms, creating a file and failing if it already exists.
+}}
 
 \item{...}{Extra arguments provided to \code{\link[=to_SingleCellExperiment]{to_SingleCellExperiment()}} or
 \code{\link[=to_Seurat]{to_Seurat()}}}

--- a/man/to_HDF5AnnData.Rd
+++ b/man/to_HDF5AnnData.Rd
@@ -35,10 +35,8 @@ ad <- AnnData(
     A = matrix(5:1, 3L, 5L),
     B = matrix(letters[1:5], 3L, 5L)
   ),
-  obs = data.frame(cell = 1:3),
-  var = data.frame(gene = 1:5),
-  obs_names = LETTERS[1:3],
-  var_names = letters[1:5]
+  obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+  var = data.frame(row.names = letters[1:5], gene = 1:5),
 )
 to_HDF5AnnData(ad, "test.h5ad")
 # remove file

--- a/man/to_HDF5AnnData.Rd
+++ b/man/to_HDF5AnnData.Rd
@@ -4,7 +4,12 @@
 \alias{to_HDF5AnnData}
 \title{Convert an AnnData object to an HDF5AnnData object}
 \usage{
-to_HDF5AnnData(adata, file, compression = c("none", "gzip", "lzf"))
+to_HDF5AnnData(
+  adata,
+  file,
+  compression = c("none", "gzip", "lzf"),
+  mode = c("w-", "r", "r+", "a", "w", "x")
+)
 }
 \arguments{
 \item{adata}{An AnnData object to be converted to HDF5AnnData.}

--- a/man/to_HDF5AnnData.Rd
+++ b/man/to_HDF5AnnData.Rd
@@ -19,6 +19,15 @@ to_HDF5AnnData(
 \item{compression}{The compression algorithm to use when writing the
 HDF5 file. Can be one of \code{"none"}, \code{"gzip"} or \code{"lzf"}. Defaults to
 \code{"none"}.}
+
+\item{mode}{The mode to open the HDF5 file.
+\itemize{
+\item \code{a} creates a new file or opens an existing one for read/write.
+\item \code{r} opens an existing file for reading.
+\item \verb{r+} opens an existing file for read/write.
+\item \code{w} creates a file, truncating any existing ones.
+\item \verb{w-}/\code{x} are synonyms, creating a file and failing if it already exists.
+}}
 }
 \value{
 An HDF5AnnData object with the same data as the input AnnData

--- a/man/to_InMemoryAnnData.Rd
+++ b/man/to_InMemoryAnnData.Rd
@@ -24,10 +24,8 @@ ad <- AnnData(
     A = matrix(5:1, 3L, 5L),
     B = matrix(letters[1:5], 3L, 5L)
   ),
-  obs = data.frame(cell = 1:3),
-  var = data.frame(gene = 1:5),
-  obs_names = LETTERS[1:3],
-  var_names = letters[1:5]
+  obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+  var = data.frame(row.names = letters[1:5], gene = 1:5)
 )
 to_InMemoryAnnData(ad)
 }

--- a/man/write_h5ad.Rd
+++ b/man/write_h5ad.Rd
@@ -20,6 +20,14 @@ write_h5ad(
 \item{compression}{The compression algorithm to use when writing the
 HDF5 file. Can be one of \code{"none"}, \code{"gzip"} or \code{"lzf"}. Defaults to
 \code{"none"}.}
+
+\item{mode}{The mode to open the HDF5 file.
+\itemize{
+\item \code{a} creates a new file or opens an existing one for read/write.
+\item \verb{r+} opens an existing file for read/write.
+\item \code{w} creates a file, truncating any existing ones
+\item \verb{w-}/\code{x} are synonyms creating a file and failing if it already exists.
+}}
 }
 \value{
 \code{path} invisibly

--- a/man/write_h5ad.Rd
+++ b/man/write_h5ad.Rd
@@ -28,16 +28,14 @@ HDF5 file. Can be one of \code{"none"}, \code{"gzip"} or \code{"lzf"}. Defaults 
 Write an H5AD file
 }
 \examples{
-adata <- AnnData(
-  X = matrix(1:15, 3L, 5L),
+ad <- AnnData(
+  X = matrix(1:5, 3L, 5L),
   layers = list(
-    A = matrix(15:1, 3L, 5L),
-    B = matrix(letters[1:15], 3L, 5L)
+    A = matrix(5:1, 3L, 5L),
+    B = matrix(letters[1:5], 3L, 5L)
   ),
-  obs = data.frame(cell = 1:3),
-  var = data.frame(gene = 1:5),
-  obs_names = LETTERS[1:3],
-  var_names = letters[1:5]
+  obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+  var = data.frame(row.names = letters[1:5], gene = 1:5)
 )
 h5ad_file <- tempfile(fileext = ".h5ad")
 write_h5ad(adata, h5ad_file)

--- a/man/write_h5ad.Rd
+++ b/man/write_h5ad.Rd
@@ -4,7 +4,12 @@
 \alias{write_h5ad}
 \title{Write H5AD}
 \usage{
-write_h5ad(object, path, compression = c("none", "gzip", "lzf"))
+write_h5ad(
+  object,
+  path,
+  compression = c("none", "gzip", "lzf"),
+  mode = c("w-", "r", "r+", "a", "w", "x")
+)
 }
 \arguments{
 \item{object}{The object to write, either a "SingleCellExperiment" or a

--- a/tests/testthat/test-HDF5-read.R
+++ b/tests/testthat/test-HDF5-read.R
@@ -1,6 +1,7 @@
 skip_if_not_installed("rhdf5")
 
-file <- system.file("extdata", "example.h5ad", package = "anndataR")
+file <- hdf5r::H5File$new(system.file("extdata", "example.h5ad", package = "anndataR"), mode = "r")
+on.exit(file$close_all())
 
 test_that("reading encoding works", {
   encoding <- read_h5ad_encoding(file, "obs")
@@ -36,9 +37,9 @@ test_that("reading recarrays works", {
   expect_true(is.list(array_list))
   expect_equal(names(array_list), c("0", "1", "2", "3", "4", "5"))
   for (array in array_list) {
-    expect_true(is.array(array))
+    expect_true(is.vector(array))
     expect_type(array, "double")
-    expect_equal(dim(array), 100)
+    expect_equal(length(array), 100)
   }
 })
 
@@ -107,7 +108,7 @@ test_that("reading dataframes works", {
   expect_equal(
     colnames(df),
     c(
-      ".index", "Float", "FloatNA", "Int", "IntNA", "Bool", "BoolNA",
+      "_index", "Float", "FloatNA", "Int", "IntNA", "Bool", "BoolNA",
       "n_genes_by_counts", "log1p_n_genes_by_counts", "total_counts",
       "log1p_total_counts", "leiden"
     )

--- a/tests/testthat/test-HDF5-read.R
+++ b/tests/testthat/test-HDF5-read.R
@@ -1,4 +1,4 @@
-skip_if_not_installed("rhdf5")
+skip_if_not_installed("hdf5r")
 
 file <- hdf5r::H5File$new(system.file("extdata", "example.h5ad", package = "anndataR"), mode = "r")
 on.exit(file$close_all())

--- a/tests/testthat/test-HDF5-read.R
+++ b/tests/testthat/test-HDF5-read.R
@@ -1,7 +1,7 @@
 skip_if_not_installed("hdf5r")
 
 file <- hdf5r::H5File$new(system.file("extdata", "example.h5ad", package = "anndataR"), mode = "r")
-on.exit(file$close_all())
+on.exit(file$close())
 
 test_that("reading encoding works", {
   encoding <- read_h5ad_encoding(file, "obs")

--- a/tests/testthat/test-HDF5-read.R
+++ b/tests/testthat/test-HDF5-read.R
@@ -103,12 +103,12 @@ test_that("reading mappings works", {
 })
 
 test_that("reading dataframes works", {
-  df <- read_h5ad_data_frame(file, "obs", include_index = TRUE)
+  df <- read_h5ad_data_frame(file, "obs")
   expect_s3_class(df, "data.frame")
   expect_equal(
     colnames(df),
     c(
-      "_index", "Float", "FloatNA", "Int", "IntNA", "Bool", "BoolNA",
+      "Float", "FloatNA", "Int", "IntNA", "Bool", "BoolNA",
       "n_genes_by_counts", "log1p_n_genes_by_counts", "total_counts",
       "log1p_total_counts", "leiden"
     )

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -1,4 +1,4 @@
-skip_if_not_installed("rhdf5")
+skip_if_not_installed("hdf5r")
 
 file <- tempfile(pattern = "hdf5_write_", fileext = ".h5ad")
 if (file.exists(file)) {

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -21,7 +21,9 @@ test_that("Writing H5AD sparse arrays works", {
   array <- matrix(rnorm(20), nrow = 5, ncol = 4)
 
   csc_array <- as(array, "CsparseMatrix")
-  expect_silent(write_h5ad_element(csc_array, h5ad_file, "csc_array", compression = "none"))
+  expect_silent(
+    write_h5ad_element(csc_array, h5ad_file, "csc_array", compression = "none")
+  )
   expect_true(hdf5_path_exists(h5ad_file, "/csc_array"))
   expect_true(hdf5_path_exists(h5ad_file, "/csc_array/data"))
   expect_true(hdf5_path_exists(h5ad_file, "/csc_array/indices"))
@@ -89,9 +91,7 @@ test_that("Writing H5AD categoricals works", {
   expect_true(hdf5_path_exists(h5ad_file, "/categorical/categories"))
   expect_true(hdf5_path_exists(h5ad_file, "/categorical/codes"))
   attrs <- rhdf5::h5readAttributes(h5ad_file, "categorical")
-  expect_true(
-    all(c("encoding-type", "encoding-version", "ordered") %in% names(attrs))
-  )
+  expect_equal(names(attrs), c("encoding-type", "encoding-version", "ordered"))
   expect_equal(attrs[["encoding-type"]], "categorical")
 })
 

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -1,18 +1,18 @@
 skip_if_not_installed("rhdf5")
 
-h5ad_file <- tempfile(pattern = "hdf5_write_", fileext = ".h5ad")
-if (file.exists(h5ad_file)) {
-  file.remove(h5ad_file)
+file <- tempfile(pattern = "hdf5_write_", fileext = ".h5ad")
+if (file.exists(file)) {
+  file.remove(file)
 }
 
-rhdf5::h5createFile(file = h5ad_file)
+file <- hdf5r::H5File$new(file, mode = "w")
 
 test_that("Writing H5AD dense arrays works", {
-  array <- matrix(rnorm(20), nrow = 5, ncol = 4)
+  value <- matrix(rnorm(20), nrow = 5, ncol = 4)
 
-  expect_silent(write_h5ad_element(array, h5ad_file, "dense_array", compression = "none"))
-  expect_true(hdf5_path_exists(h5ad_file, "/dense_array"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "dense_array")
+  expect_silent(write_h5ad_element(value, file, "dense_array", compression = "none"))
+  expect_true(hdf5_path_exists(file, "/dense_array"))
+  attrs <- hdf5r::h5attributes(file[["dense_array"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "array")
 })
@@ -22,23 +22,23 @@ test_that("Writing H5AD sparse arrays works", {
 
   csc_array <- as(array, "CsparseMatrix")
   expect_silent(
-    write_h5ad_element(csc_array, h5ad_file, "csc_array", compression = "none")
+    write_h5ad_element(csc_array, file, "csc_array", compression = "none")
   )
-  expect_true(hdf5_path_exists(h5ad_file, "/csc_array"))
-  expect_true(hdf5_path_exists(h5ad_file, "/csc_array/data"))
-  expect_true(hdf5_path_exists(h5ad_file, "/csc_array/indices"))
-  expect_true(hdf5_path_exists(h5ad_file, "/csc_array/indptr"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "csc_array")
+  expect_true(hdf5_path_exists(file, "/csc_array"))
+  expect_true(hdf5_path_exists(file, "/csc_array/data"))
+  expect_true(hdf5_path_exists(file, "/csc_array/indices"))
+  expect_true(hdf5_path_exists(file, "/csc_array/indptr"))
+  attrs <- hdf5r::h5attributes(file[["csc_array"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "csc_matrix")
 
   csr_array <- as(array, "RsparseMatrix")
-  expect_silent(write_h5ad_element(csr_array, h5ad_file, "csr_array", compression = "none"))
-  expect_true(hdf5_path_exists(h5ad_file, "/csr_array"))
-  expect_true(hdf5_path_exists(h5ad_file, "/csr_array/data"))
-  expect_true(hdf5_path_exists(h5ad_file, "/csr_array/indices"))
-  expect_true(hdf5_path_exists(h5ad_file, "/csr_array/indptr"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "csr_array")
+  expect_silent(write_h5ad_element(csr_array, file, "csr_array", compression = "none"))
+  expect_true(hdf5_path_exists(file, "/csr_array"))
+  expect_true(hdf5_path_exists(file, "/csr_array/data"))
+  expect_true(hdf5_path_exists(file, "/csr_array/indices"))
+  expect_true(hdf5_path_exists(file, "/csr_array/indptr"))
+  attrs <- hdf5r::h5attributes(file[["csr_array"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "csr_matrix")
 })
@@ -47,9 +47,9 @@ test_that("Writing H5AD nullable booleans works", {
   nullable <- c(TRUE, TRUE, FALSE, FALSE, FALSE)
   nullable[5] <- NA
 
-  expect_silent(write_h5ad_element(nullable, h5ad_file, "nullable_bool"))
-  expect_true(hdf5_path_exists(h5ad_file, "/nullable_bool"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "nullable_bool")
+  expect_silent(write_h5ad_element(nullable, file, "nullable_bool"))
+  expect_true(hdf5_path_exists(file, "/nullable_bool"))
+  attrs <- hdf5r::h5attributes(file[["nullable_bool"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "nullable-boolean")
 })
@@ -58,9 +58,9 @@ test_that("Writing H5AD nullable integers works", {
   nullable <- as.integer(1:5)
   nullable[5] <- NA
 
-  expect_silent(write_h5ad_element(nullable, h5ad_file, "nullable_int"))
-  expect_true(hdf5_path_exists(h5ad_file, "/nullable_int"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "nullable_int")
+  expect_silent(write_h5ad_element(nullable, file, "nullable_int"))
+  expect_true(hdf5_path_exists(file, "/nullable_int"))
+  attrs <- hdf5r::h5attributes(file[["nullable_int"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "nullable-integer")
 })
@@ -68,17 +68,17 @@ test_that("Writing H5AD nullable integers works", {
 test_that("Writing H5AD string arrays works", {
   string <- LETTERS[1:5]
 
-  expect_silent(write_h5ad_element(string, h5ad_file, "string_array"))
-  expect_true(hdf5_path_exists(h5ad_file, "/string_array"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "string_array")
+  expect_silent(write_h5ad_element(string, file, "string_array"))
+  expect_true(hdf5_path_exists(file, "/string_array"))
+  attrs <- hdf5r::h5attributes(file[["string_array"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "string-array")
 
   string2d <- matrix(LETTERS[1:20], nrow = 5, ncol = 4)
 
-  expect_silent(write_h5ad_element(string2d, h5ad_file, "string_array2D"))
-  expect_true(hdf5_path_exists(h5ad_file, "/string_array2D"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "string_array2D")
+  expect_silent(write_h5ad_element(string2d, file, "string_array2D"))
+  expect_true(hdf5_path_exists(file, "/string_array2D"))
+  attrs <- hdf5r::h5attributes(file[["string_array2D"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "string-array")
 })
@@ -86,11 +86,11 @@ test_that("Writing H5AD string arrays works", {
 test_that("Writing H5AD categoricals works", {
   categorical <- factor(LETTERS[1:5])
 
-  expect_no_error(write_h5ad_element(categorical, h5ad_file, "categorical"))
-  expect_true(hdf5_path_exists(h5ad_file, "/categorical"))
-  expect_true(hdf5_path_exists(h5ad_file, "/categorical/categories"))
-  expect_true(hdf5_path_exists(h5ad_file, "/categorical/codes"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "categorical")
+  expect_no_error(write_h5ad_element(categorical, file, "categorical"))
+  expect_true(hdf5_path_exists(file, "/categorical"))
+  expect_true(hdf5_path_exists(file, "/categorical/categories"))
+  expect_true(hdf5_path_exists(file, "/categorical/codes"))
+  attrs <- hdf5r::h5attributes(file[["categorical"]])
   expect_equal(names(attrs), c("encoding-type", "encoding-version", "ordered"))
   expect_equal(attrs[["encoding-type"]], "categorical")
 })
@@ -98,9 +98,9 @@ test_that("Writing H5AD categoricals works", {
 test_that("Writing H5AD string scalars works", {
   string <- "A"
 
-  expect_silent(write_h5ad_element(string, h5ad_file, "string_scalar"))
-  expect_true(hdf5_path_exists(h5ad_file, "/string_scalar"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "string_scalar")
+  expect_silent(write_h5ad_element(string, file, "string_scalar"))
+  expect_true(hdf5_path_exists(file, "/string_scalar"))
+  attrs <- hdf5r::h5attributes(file[["string_scalar"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "string")
 })
@@ -108,9 +108,9 @@ test_that("Writing H5AD string scalars works", {
 test_that("Writing H5AD numeric scalars works", {
   number <- 1.0
 
-  expect_silent(write_h5ad_element(number, h5ad_file, "numeric_scalar"))
-  expect_true(hdf5_path_exists(h5ad_file, "/numeric_scalar"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "numeric_scalar")
+  expect_silent(write_h5ad_element(number, file, "numeric_scalar"))
+  expect_true(hdf5_path_exists(file, "/numeric_scalar"))
+  attrs <- hdf5r::h5attributes(file[["numeric_scalar"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "numeric-scalar")
 })
@@ -124,17 +124,17 @@ test_that("Writing H5AD mappings works", {
     scalar = 2
   )
 
-  expect_silent(write_h5ad_element(mapping, h5ad_file, "mapping", compression = "none"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/array"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/sparse"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/sparse/data"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/sparse/indices"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/sparse/indptr"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/string"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/numeric"))
-  expect_true(hdf5_path_exists(h5ad_file, "/mapping/scalar"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "mapping")
+  expect_silent(write_h5ad_element(mapping, file, "mapping", compression = "none"))
+  expect_true(hdf5_path_exists(file, "/mapping"))
+  expect_true(hdf5_path_exists(file, "/mapping/array"))
+  expect_true(hdf5_path_exists(file, "/mapping/sparse"))
+  expect_true(hdf5_path_exists(file, "/mapping/sparse/data"))
+  expect_true(hdf5_path_exists(file, "/mapping/sparse/indices"))
+  expect_true(hdf5_path_exists(file, "/mapping/sparse/indptr"))
+  expect_true(hdf5_path_exists(file, "/mapping/string"))
+  expect_true(hdf5_path_exists(file, "/mapping/numeric"))
+  expect_true(hdf5_path_exists(file, "/mapping/scalar"))
+  attrs <- hdf5r::h5attributes(file[["mapping"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "dict")
 })
@@ -145,12 +145,12 @@ test_that("Writing H5AD data frames works", {
     Numbers = 1:5
   )
 
-  expect_silent(write_h5ad_element(df, h5ad_file, "dataframe"))
-  expect_true(hdf5_path_exists(h5ad_file, "/dataframe"))
-  expect_true(hdf5_path_exists(h5ad_file, "/dataframe/Letters"))
-  expect_true(hdf5_path_exists(h5ad_file, "/dataframe/Numbers"))
-  expect_true(hdf5_path_exists(h5ad_file, "/dataframe/_index"))
-  attrs <- rhdf5::h5readAttributes(h5ad_file, "dataframe")
+  expect_silent(write_h5ad_element(df, file, "dataframe"))
+  expect_true(hdf5_path_exists(file, "/dataframe"))
+  expect_true(hdf5_path_exists(file, "/dataframe/Letters"))
+  expect_true(hdf5_path_exists(file, "/dataframe/Numbers"))
+  expect_true(hdf5_path_exists(file, "/dataframe/_index"))
+  attrs <- hdf5r::h5attributes(file[["dataframe"]])
   expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
   expect_equal(attrs[["encoding-type"]], "dataframe")
   expect_true(all(c("_index", "column-order") %in% names(attrs)))

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -186,9 +186,7 @@ test_that("writing gzip compressed files works", {
   adata <- AnnData(
     X = non_random_X,
     obs = dummy$obs,
-    var = dummy$var,
-    obs_names = dummy$obs_names,
-    var_names = dummy$var_names
+    var = dummy$var
   )
 
   h5ad_file_none <- tempfile(pattern = "hdf5_write_none_", fileext = ".h5ad")
@@ -207,9 +205,7 @@ test_that("writing lzf compressed files works", {
   adata <- AnnData(
     X = non_random_X,
     obs = dummy$obs,
-    var = dummy$var,
-    obs_names = dummy$obs_names,
-    var_names = dummy$var_names
+    var = dummy$var
   )
 
   h5ad_file_none <- tempfile(pattern = "hdf5_write_none_", fileext = ".h5ad")

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -88,9 +88,10 @@ test_that("Writing H5AD categoricals works", {
   expect_true(hdf5_path_exists(h5ad_file, "/categorical"))
   expect_true(hdf5_path_exists(h5ad_file, "/categorical/categories"))
   expect_true(hdf5_path_exists(h5ad_file, "/categorical/codes"))
-  expect_true(hdf5_path_exists(h5ad_file, "/categorical/ordered"))
   attrs <- rhdf5::h5readAttributes(h5ad_file, "categorical")
-  expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
+  expect_true(
+    all(c("encoding-type", "encoding-version", "ordered") %in% names(attrs))
+  )
   expect_equal(attrs[["encoding-type"]], "categorical")
 })
 

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -161,7 +161,7 @@ test_that("Writing H5AD data frames works", {
 test_that("writing H5AD from SingleCellExperiment works", {
   skip_if_not_installed("SingleCellExperiment")
 
-  file <- withr::local_file("SingleCellExperiment.h5ad")
+  file <- withr::local_file(tempfile(fileext = ".h5ad"))
 
   sce <- generate_dataset(format = "SingleCellExperiment")
   write_h5ad(sce, file)
@@ -172,7 +172,7 @@ test_that("writing H5AD from Seurat works", {
   skip_if_not_installed("SeuratObject")
   skip("while Seurat converter is failing")
 
-  file <- withr::local_file("Seurat.h5ad")
+  file <- withr::local_file(tempfile(fileext = ".h5ad"))
 
   seurat <- generate_dataset(format = "Seurat")
   write_h5ad(seurat, file)

--- a/tests/testthat/test-HDF5AnnData.R
+++ b/tests/testthat/test-HDF5AnnData.R
@@ -58,8 +58,8 @@ test_that("obsm/ varm validation", {
 
   adata <- AnnData(
     X = mtx,
-    obs_names = as.character(1:N_OBS),
-    var_names = as.character(1:N_VAR)
+    obs = data.frame(row.names = as.character(1:N_OBS)),
+    var = data.frame(row.names = as.character(1:N_VAR))
   )
 
   adata$obsm <- list(PCA = matrix(0, N_OBS, 4))
@@ -74,8 +74,8 @@ test_that("obsp/ varp validation", {
   N_VAR <- 3
 
   adata <- AnnData(
-    obs_names = as.character(1:N_OBS),
-    var_names = as.character(1:N_VAR)
+    obs = data.frame(row.names = as.character(1:N_OBS)),
+    var = data.frame(row.names = as.character(1:N_VAR))
   )
 
   adata$obsp <- list(graph1 = matrix(0, N_OBS, N_OBS))
@@ -138,13 +138,15 @@ test_that("reading var names works", {
 # SETTERS ----------------------------------------------------------------
 test_that("creating empty H5AD works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  expect_silent(HDF5AnnData$new(h5ad_file, obs_names = 1:10, var_names = 1:20))
+  expect_silent(HDF5AnnData$new(h5ad_file))
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_X, status=done
 test_that("writing X works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  h5ad <- HDF5AnnData$new(h5ad_file, obs_names = 1:10, var_names = 1:20)
+  obs <- data.frame(row.names = 1:10)
+  var <- data.frame(row.names = 1:20)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
 
   X <- matrix(rnorm(10 * 20), nrow = 10, ncol = 20)
   expect_silent(h5ad$X <- X)
@@ -153,7 +155,9 @@ test_that("writing X works", {
 # trackstatus: class=HDF5AnnData, feature=test_set_layers, status=done
 test_that("writing layers works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  h5ad <- HDF5AnnData$new(h5ad_file, obs_names = 1:10, var_names = 1:20)
+  obs <- data.frame(row.names = 1:10)
+  var <- data.frame(row.names = 1:20)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
 
   X <- matrix(rnorm(10 * 20), nrow = 10, ncol = 20)
   expect_silent(h5ad$layers <- list(layer1 = X, layer2 = X))
@@ -162,35 +166,41 @@ test_that("writing layers works", {
 # trackstatus: class=HDF5AnnData, feature=test_set_obs, status=done
 test_that("writing obs works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  h5ad <- HDF5AnnData$new(h5ad_file, obs_names = 1:10, var_names = 1:20)
+  obs <- data.frame(row.names = 1:10)
+  var <- data.frame(row.names = 1:20)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
 
   obs <- data.frame(
     Letters = LETTERS[1:10],
     Numbers = 1:10,
     row.names = paste0("Row", 1:10)
   )
-  expect_warning(h5ad$obs <- obs, "should not have any rownames")
-  expect_identical(h5ad$obs_names, 1:10)
+  h5ad$obs <- obs
+  expect_identical(h5ad$obs_names, paste0("Row", 1:10))
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_var, status=done
 test_that("writing var works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  h5ad <- HDF5AnnData$new(h5ad_file, obs_names = 1:10, var_names = 1:20)
+  obs <- data.frame(row.names = 1:10)
+  var <- data.frame(row.names = 1:20)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
 
   var <- data.frame(
     Letters = LETTERS[1:20],
     Numbers = 1:20,
     row.names = paste0("Row", 1:20)
   )
-  expect_warning(h5ad$var <- var, "should not have any rownames")
-  expect_identical(h5ad$var_names, 1:20)
+  h5ad$var <- var
+  expect_identical(h5ad$var_names, paste0("Row", 1:20))
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_obs_names, status=done
 test_that("writing obs names works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  h5ad <- HDF5AnnData$new(h5ad_file, obs_names = 1:10, var_names = 1:20)
+  obs <- data.frame(row.names = 1:10)
+  var <- data.frame(row.names = 1:20)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
 
   h5ad$obs_names <- LETTERS[1:10]
   expect_identical(h5ad$obs_names, LETTERS[1:10])
@@ -199,7 +209,9 @@ test_that("writing obs names works", {
 # trackstatus: class=HDF5AnnData, feature=test_set_var_names, status=done
 test_that("writing var names works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  h5ad <- HDF5AnnData$new(h5ad_file, obs_names = 1:10, var_names = 1:20)
+  obs <- data.frame(row.names = 1:10)
+  var <- data.frame(row.names = 1:20)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
 
   h5ad$var_names <- LETTERS[1:20]
   expect_identical(h5ad$var_names, LETTERS[1:20])

--- a/tests/testthat/test-HDF5AnnData.R
+++ b/tests/testthat/test-HDF5AnnData.R
@@ -1,4 +1,4 @@
-skip_if_not_installed("rhdf5")
+skip_if_not_installed("hdf5r")
 
 file <- system.file("extdata", "example.h5ad", package = "anndataR")
 

--- a/tests/testthat/test-HDF5AnnData.R
+++ b/tests/testthat/test-HDF5AnnData.R
@@ -8,6 +8,8 @@ test_that("opening H5AD works", {
   rm(adata)
 })
 
+gc()
+
 adata <- HDF5AnnData$new(file)
 
 # GETTERS ----------------------------------------------------------------

--- a/tests/testthat/test-HDF5AnnData.R
+++ b/tests/testthat/test-HDF5AnnData.R
@@ -5,6 +5,7 @@ file <- system.file("extdata", "example.h5ad", package = "anndataR")
 test_that("opening H5AD works", {
   adata <- HDF5AnnData$new(file)
   expect_true(inherits(adata, "HDF5AnnData"))
+  rm(adata)
 })
 
 adata <- HDF5AnnData$new(file)
@@ -84,6 +85,12 @@ test_that("obsp/ varp validation", {
   expect_error(adata$varp <- list(graph1 = matrix(0, 4, 4)))
 })
 
+
+
+
+
+
+
 # trackstatus: class=HDF5AnnData, feature=test_get_obs, status=done
 test_that("reading obs works", {
   obs <- adata$obs
@@ -96,6 +103,11 @@ test_that("reading obs works", {
     )
   )
 })
+
+
+
+
+
 
 # trackstatus: class=HDF5AnnData, feature=test_get_var, status=done
 test_that("reading var works", {

--- a/tests/testthat/test-HDF5AnnData.R
+++ b/tests/testthat/test-HDF5AnnData.R
@@ -5,10 +5,8 @@ file <- system.file("extdata", "example.h5ad", package = "anndataR")
 test_that("opening H5AD works", {
   adata <- HDF5AnnData$new(file)
   expect_true(inherits(adata, "HDF5AnnData"))
-  rm(adata)
+  adata$close()
 })
-
-gc()
 
 adata <- HDF5AnnData$new(file)
 

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -8,8 +8,8 @@ test_that("to_Seurat with inmemoryanndata", {
   )
   # running to_seurat when ad0$X is null probably doesn't make any sense
   ad0 <- AnnData(
-    obs_names = letters[1:5],
-    var_names = LETTERS[1:10]
+    obs = data.frame(row.names = letters[1:5]),
+    var = data.frame(row.names = LETTERS[1:10])
   )
 
   # TODO: remove suppressWarnings when to_Seurat gets updated

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -4,9 +4,7 @@ test_that("to_Seurat with inmemoryanndata", {
   ad <- AnnData(
     X = dummy$X,
     obs = dummy$obs,
-    var = dummy$var,
-    obs_names = dummy$obs_names,
-    var_names = dummy$var_names
+    var = dummy$var
   )
   # running to_seurat when ad0$X is null probably doesn't make any sense
   ad0 <- AnnData(

--- a/tests/testthat/test-SingleCellExperiment.R
+++ b/tests/testthat/test-SingleCellExperiment.R
@@ -1,14 +1,12 @@
 test_that("to_SingleCellExperiment() works", {
   ad <- AnnData(
     X = matrix(1:5, 3L, 5L),
-    obs = data.frame(cell = 1:3),
-    var = data.frame(gene = 1:5),
-    obs_names = LETTERS[1:3],
-    var_names = letters[1:5]
+    obs = data.frame(row.names = letters[1:5], cell = 1:3),
+    var = data.frame(row.names = LETTERS[1:10], gene = 1:5)
   )
   ad0 <- AnnData(
-    obs_names = LETTERS[1:6],
-    var_names = letters[1:8]
+    obs = data.frame(row.names = letters[1:5]),
+    var = data.frame(row.names = LETTERS[1:10])
   )
 
   # conversion works

--- a/tests/testthat/test-generate_dataset.R
+++ b/tests/testthat/test-generate_dataset.R
@@ -3,7 +3,7 @@ test_that("generating dummy data works", {
   expect_type(dataset, "list")
   expect_setequal(
     names(dataset),
-    c("X", "obs", "obsp", "obsm", "obs_names", "var", "varp", "varm", "var_names", "layers", "uns")
+    c("X", "obs", "obsp", "obsm", "var", "varp", "varm", "layers", "uns")
   )
   expect_identical(dim(dataset$X), c(10L, 20L))
 })

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -14,8 +14,8 @@ for (layer_name in layer_names) {
     # create anndata
     ad <- AnnData(
       X = data$layers[[layer_name]],
-      obs_names = data$obs_names,
-      var_names = data$var_names
+      obs = data$obs[, c(), drop = FALSE],
+      var = data$var[, c(), drop = FALSE]
     )
 
     # write to file
@@ -84,8 +84,8 @@ for (layer_name in r2py_names) {
     ad <- HDF5AnnData$new(
       file = filename,
       X = X,
-      obs_names = data$obs_names,
-      var_names = data$var_names
+      obs = data$obs[, c(), drop = FALSE],
+      var = data$var[, c(), drop = FALSE]
     )
 
     # read from file

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -39,14 +39,14 @@ for (name in layer_names) {
   test_that(paste0("reticulate->hdf5 with layer '", name, "'"), {
     # add rownames
     X <- data$layers[[name]]
-    rownames(X) <- data$obs_names
-    colnames(X) <- data$var_names
+    obs <- data.frame(row.names = rownames(data$obs))
+    var <- data.frame(row.names = rownames(data$var))
 
     # create anndata
     ad <- anndata::AnnData(
       X = X,
-      obs = data.frame(row.names = data$obs_names),
-      var = data.frame(row.names = data$var_names)
+      obs = obs,
+      var = var
     )
 
     # write to file

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -19,7 +19,7 @@ for (layer_name in layer_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("roundtrip_layer_", layer_name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     write_h5ad(ad, filename)
 
     # read from file
@@ -50,7 +50,7 @@ for (name in layer_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("reticulate_to_hdf5_layer_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     ad$write_h5ad(filename)
 
     # read from file
@@ -72,7 +72,7 @@ r2py_names <- r2py_names[!grepl("rsparse", r2py_names)]
 for (layer_name in r2py_names) {
   test_that(paste0("hdf5->reticulate with layer '", layer_name, "'"), {
     # write to file
-    filename <- withr::local_file(paste0("hdf5_to_reticulate_layer_", layer_name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 
     # strip rownames
     X <- data$layers[[layer_name]]

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -1,5 +1,5 @@
 skip_if_no_anndata()
-skip_if_not_installed("rhdf5")
+skip_if_not_installed("hdf5r")
 
 data <- generate_dataset(10L, 20L)
 

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -14,8 +14,8 @@ for (name in layer_names) {
     # create anndata
     ad <- AnnData(
       layers = data$layers[name],
-      obs_names = data$obs_names,
-      var_names = data$var_names
+      obs = data$obs,
+      var = data$var
     )
 
     # write to file
@@ -86,8 +86,8 @@ for (name in r2py_names) {
     ad <- HDF5AnnData$new(
       file = filename,
       layers = layers,
-      obs_names = data$obs_names,
-      var_names = data$var_names
+      obs = data$obs,
+      var = data$var
     )
 
     # read from file

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -22,6 +22,8 @@ for (name in layer_names) {
     filename <- withr::local_file(paste0("roundtrip_layer_", name, ".h5ad"))
     write_h5ad(ad, filename)
 
+    gc()
+
     # read from file
     ad_new <- read_h5ad(filename, to = "HDF5AnnData")
 
@@ -39,15 +41,15 @@ for (name in layer_names) {
   test_that(paste0("reticulate->hdf5 with layer '", name, "'"), {
     # add rownames
     layers <- data$layers[name]
-    rownames(layers[[name]]) <- data$obs_names
-    colnames(layers[[name]]) <- data$var_names
+    obs <- data.frame(row.names = rownames(data$obs))
+    var <- data.frame(row.names = rownames(data$var))
 
     # create anndata
     ad <- anndata::AnnData(
       layers = layers,
       shape = dim(data$X),
-      obs = data.frame(row.names = data$obs_names),
-      var = data.frame(row.names = data$var_names)
+      obs = obs,
+      var = var
     )
 
     # write to file
@@ -89,6 +91,8 @@ for (name in r2py_names) {
       obs = data$obs,
       var = data$var
     )
+    rm(ad)
+    gc()
 
     # read from file
     ad_new <- anndata::read_h5ad(filename)

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -19,7 +19,7 @@ for (name in layer_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("roundtrip_layer_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     write_h5ad(ad, filename)
 
     gc()
@@ -53,7 +53,7 @@ for (name in layer_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("reticulate_to_hdf5_layer_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     ad$write_h5ad(filename)
 
     # read from file
@@ -77,7 +77,7 @@ r2py_names <- r2py_names[!grepl("with_nas", r2py_names)]
 for (name in r2py_names) {
   test_that(paste0("hdf5->reticulate with layer '", name, "'"), {
     # write to file
-    filename <- withr::local_file(paste0("hdf5_to_reticulate_layer_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 
     # strip rownames
     layers <- data$layers[name]

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -83,13 +83,19 @@ for (name in r2py_names) {
     colnames(layers[[name]]) <- NULL
 
     # make anndata
-    ad <- HDF5AnnData$new(
-      file = filename,
+    ad <- AnnData(
       layers = layers,
       obs = data$obs,
       var = data$var
     )
-    ad$close()
+    write_h5ad(ad, filename)
+    # ad <- HDF5AnnData$new(
+    #   file = filename,
+    #   layers = layers,
+    #   obs = data$obs,
+    #   var = data$var
+    # )
+    # ad$close()
 
     # read from file
     ad_new <- anndata::read_h5ad(filename)

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -22,8 +22,6 @@ for (name in layer_names) {
     filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     write_h5ad(ad, filename)
 
-    gc()
-
     # read from file
     ad_new <- read_h5ad(filename, to = "HDF5AnnData")
 
@@ -91,8 +89,7 @@ for (name in r2py_names) {
       obs = data$obs,
       var = data$var
     )
-    rm(ad)
-    gc()
+    ad$close()
 
     # read from file
     ad_new <- anndata::read_h5ad(filename)

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -1,5 +1,5 @@
 skip_if_no_anndata()
-skip_if_not_installed("rhdf5")
+skip_if_not_installed("hdf5r")
 
 data <- generate_dataset(10L, 20L)
 

--- a/tests/testthat/test-roundtrip-obsmvarm.R
+++ b/tests/testthat/test-roundtrip-obsmvarm.R
@@ -15,8 +15,8 @@
 #     ad <- AnnData(
 #       obsm = data$obsm[name],
 #       varm = data$varm[name],
-#       obs_names = data$obs_names,
-#       var_names = data$var_names
+#       obs = data$obs[, c(), drop = FALSE]
+#       var = data$var[, c(), drop = FALSE]
 #     )
 
 #     # write to file
@@ -101,8 +101,8 @@
 #       file = filename,
 #       obsm = obsm,
 #       varm = varm,
-#       obs_names = data$obs_names,
-#       var_names = data$var_names
+#       obs = data$obs[, c(), drop = FALSE]
+#       var = data$var[, c(), drop = FALSE]
 #     )
 
 #     # read from file

--- a/tests/testthat/test-roundtrip-obsmvarm.R
+++ b/tests/testthat/test-roundtrip-obsmvarm.R
@@ -1,7 +1,7 @@
 # TODO: re-enable
 # nolint start
 # skip_if_no_anndata()
-# skip_if_not_installed("rhdf5")
+# skip_if_not_installed("hdf5r")
 
 # data <- generate_dataset(10L, 20L)
 

--- a/tests/testthat/test-roundtrip-obsmvarm.R
+++ b/tests/testthat/test-roundtrip-obsmvarm.R
@@ -20,7 +20,7 @@
 #     )
 
 #     # write to file
-#     filename <- withr::local_file(paste0("roundtrip_obsmvarm_", name, ".h5ad"))
+#     filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 #     write_h5ad(ad, filename)
 
 #     # read from file
@@ -65,7 +65,7 @@
 #     )
 
 #     # write to file
-#     filename <- withr::local_file(paste0("reticulate_to_hdf5_obsmvarm_", name, ".h5ad"))
+#     filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 #     ad$write_h5ad(filename)
 
 #     # read from file
@@ -88,7 +88,7 @@
 # for (name in r2py_names) {
 #   test_that(paste0("hdf5->reticulate with obsm and varm '", name, "'"), {
 #     # write to file
-#     filename <- withr::local_file(paste0("hdf5_to_reticulate_obsmvarm_", name, ".h5ad"))
+#     filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 
 #     # strip rownames
 #     obsm <- data$obsm[name]

--- a/tests/testthat/test-roundtrip-obspvarp.R
+++ b/tests/testthat/test-roundtrip-obspvarp.R
@@ -11,8 +11,8 @@
 #     ad <- AnnData(
 #       obsp = data$obsp[name],
 #       varp = data$varp[name],
-#       obs_names = data$obs_names,
-#       var_names = data$var_names
+#       obs = data$obs[, c(), drop = FALSE]
+#       var = data$var[, c(), drop = FALSE]
 #     )
 
 #     # write to file
@@ -92,8 +92,8 @@
 #       file = filename,
 #       obsp = obsp,
 #       varp = varp,
-#       obs_names = data$obs_names,
-#       var_names = data$var_names
+#       obs = data$obs[, c(), drop = FALSE]
+#       var = data$var[, c(), drop = FALSE]
 #     )
 
 #     # read from file

--- a/tests/testthat/test-roundtrip-obspvarp.R
+++ b/tests/testthat/test-roundtrip-obspvarp.R
@@ -16,7 +16,7 @@
 #     )
 
 #     # write to file
-#     filename <- withr::local_file(paste0("roundtrip_obspvarp_", name, ".h5ad"))
+#     filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 #     write_h5ad(ad, filename)
 
 #     # read from file
@@ -56,7 +56,7 @@
 #     )
 
 #     # write to file
-#     filename <- withr::local_file(paste0("reticulate_to_hdf5_obspvarp_", name, ".h5ad"))
+#     filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 #     ad$write_h5ad(filename)
 
 #     # read from file
@@ -79,7 +79,7 @@
 # for (name in names(data$obsp)) {
 #   test_that(paste0("hdf5->reticulate with obsp and varp '", name, "'"), {
 #     # write to file
-#     filename <- withr::local_file(paste0("hdf5_to_reticulate_obspvarp_", name, ".h5ad"))
+#     filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 
 #     # strip rownames
 #     obsp <- data$obsp[name]

--- a/tests/testthat/test-roundtrip-obspvarp.R
+++ b/tests/testthat/test-roundtrip-obspvarp.R
@@ -1,7 +1,7 @@
 # TODO: re-enable
 # nolint start
 # skip_if_no_anndata()
-# skip_if_not_installed("rhdf5")
+# skip_if_not_installed("hdf5r")
 
 # data <- generate_dataset(10L, 20L)
 

--- a/tests/testthat/test-roundtrip-obsvar.R
+++ b/tests/testthat/test-roundtrip-obsvar.R
@@ -22,7 +22,7 @@ for (name in test_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("roundtrip_obsvar_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     write_h5ad(ad, filename)
 
     # read from file
@@ -52,7 +52,7 @@ for (name in test_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("reticulate_to_hdf5_obsvar_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     ad$write_h5ad(filename)
 
     # read from file
@@ -70,7 +70,7 @@ for (name in test_names) {
 for (name in test_names) {
   test_that(paste0("hdf5->reticulate with obs and var '", name, "'"), {
     # write to file
-    filename <- withr::local_file(paste0("hdf5_to_reticulate_obsvar_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 
     # strip rownames
     obs <- data$obs[, name, drop = FALSE]

--- a/tests/testthat/test-roundtrip-obsvar.R
+++ b/tests/testthat/test-roundtrip-obsvar.R
@@ -82,7 +82,6 @@ for (name in test_names) {
       var = var
     )
     write_h5ad(ad, filename)
-    gc()
 
     # read from file
     ad_new <- anndata::read_h5ad(filename)

--- a/tests/testthat/test-roundtrip-obsvar.R
+++ b/tests/testthat/test-roundtrip-obsvar.R
@@ -19,8 +19,6 @@ for (name in test_names) {
       X = data$X,
       obs = data$obs[, name, drop = FALSE],
       var = data$var[, name, drop = FALSE],
-      obs_names = data$obs_names,
-      var_names = data$var_names
     )
 
     # write to file
@@ -52,8 +50,6 @@ for (name in test_names) {
       obs = data$obs[, name, drop = FALSE],
       var = data$var[, name, drop = FALSE]
     )
-    ad$obs_names <- data$obs_names
-    ad$var_names <- data$var_names
 
     # write to file
     filename <- withr::local_file(paste0("reticulate_to_hdf5_obsvar_", name, ".h5ad"))
@@ -79,27 +75,20 @@ for (name in test_names) {
     # strip rownames
     obs <- data$obs[, name, drop = FALSE]
     var <- data$var[, name, drop = FALSE]
-    rownames(obs[[name]]) <- NULL
-    rownames(var[[name]]) <- NULL
 
     # create anndata
-    ad <- HDF5AnnData$new(
-      file = filename,
+    ad <- AnnData(
       obs = obs,
-      var = var,
-      obs_names = data$obs_names,
-      var_names = data$var_names
+      var = var
     )
+    write_h5ad(ad, filename)
+    gc()
 
     # read from file
     ad_new <- anndata::read_h5ad(filename)
 
     # expect slots are unchanged
     obs_ <- ad_new$obs[[name]]
-    if (!is.null(obs_)) {
-      rownames(obs_) <- NULL
-      colnames(obs_) <- NULL
-    }
     expect_equal(
       obs_,
       data$obs[[name]],

--- a/tests/testthat/test-roundtrip-obsvar.R
+++ b/tests/testthat/test-roundtrip-obsvar.R
@@ -1,5 +1,5 @@
 skip_if_no_anndata()
-skip_if_not_installed("rhdf5")
+skip_if_not_installed("hdf5r")
 
 data <- generate_dataset(10L, 20L)
 

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -29,7 +29,7 @@ for (name in uns_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("roundtrip_uns_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     write_h5ad(ad, filename)
 
     # read from file
@@ -55,7 +55,7 @@ for (name in uns_names) {
     )
 
     # write to file
-    filename <- withr::local_file(paste0("reticulate_to_hdf5_uns_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
     ad$write_h5ad(filename)
 
     # read from file
@@ -74,7 +74,7 @@ for (name in uns_names) {
 for (name in uns_names) {
   test_that(paste0("hdf5->reticulate with uns '", name, "'"), {
     # write to file
-    filename <- withr::local_file(paste0("hdf5_to_reticulate_uns_", name, ".h5ad"))
+    filename <- withr::local_file(tempfile(fileext = ".h5ad"))
 
     # make anndata
     ad <- AnnData(

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -49,8 +49,8 @@ for (name in uns_names) {
   test_that(paste0("reticulate->hdf5 with uns '", name, "'"), {
     # create anndata
     ad <- anndata::AnnData(
-      obs = data.frame(row.names = data$obs_names),
-      var = data.frame(row.names = data$var_names),
+      obs = data.frame(row.names = rownames(data$obs)),
+      var = data.frame(row.names = rownames(data$var)),
       uns = data$uns[name]
     )
 
@@ -77,12 +77,13 @@ for (name in uns_names) {
     filename <- withr::local_file(paste0("hdf5_to_reticulate_uns_", name, ".h5ad"))
 
     # make anndata
-    ad <- HDF5AnnData$new(
-      file = filename,
-      obs_names = data$obs_names,
-      var_names = data$var_names,
+    ad <- AnnData(
+      obs = data.frame(row.names = rownames(data$obs)),
+      var = data.frame(row.names = rownames(data$var)),
       uns = data$uns[name]
     )
+    write_h5ad(ad, filename)
+    gc()
 
     # read from file
     ad_new <- anndata::read_h5ad(filename)

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -23,8 +23,8 @@ for (name in uns_names) {
   test_that(paste0("roundtrip with uns '", name, "'"), {
     # create anndata
     ad <- AnnData(
-      obs_names = data$obs_names,
-      var_names = data$var_names,
+      obs = data.frame(row.names = rownames(data$obs)),
+      var = data.frame(row.names = rownames(data$var)),
       uns = data$uns[name]
     )
 

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -83,7 +83,6 @@ for (name in uns_names) {
       uns = data$uns[name]
     )
     write_h5ad(ad, filename)
-    gc()
 
     # read from file
     ad_new <- anndata::read_h5ad(filename)

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -1,5 +1,5 @@
 skip_if_no_anndata()
-skip_if_not_installed("rhdf5")
+skip_if_not_installed("hdf5r")
 
 data <- generate_dataset(10L, 20L)
 

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -88,10 +88,8 @@ adata <- AnnData(
     A = matrix(5:1, 3L, 5L),
     B = matrix(letters[1:5], 3L, 5L)
   ),
-  obs = data.frame(cell = 1:3),
-  var = data.frame(gene = 1:5),
-  obs_names = LETTERS[1:3],
-  var_names = letters[1:5]
+  obs = data.frame(row.names = LETTERS[1:3], cell = 1:3),
+  var = data.frame(row.names = letters[1:5], gene = 1:5)
 )
 adata
 ```


### PR DESCRIPTION
Hey @lazappi !

Since the lack of support for boolean attributes remains a blocking issue with rhdf5, I decided to give hdf5r a try. 

The current PR seems to work a lot better, still has some issues when writing h5ad files with anndataR and then trying to read them out again in Python anndata. I need to do some experiments with writing the same h5ad file from anndataR and Python anndata and seeing where the differences lie. I'm starting to think that in our implementation of `hdf5_write_compressed`, the `dtype` and `space` should not be guessed but instead be manually specified depending on which `write_h5ad_*` function it was called from.

---

Luckily, our internal `read_*`/`write_*` functions stayed pretty much the same since all `rhdf5::*` could mostly be substituted with the corresponding `hdf5r::*` functions.

---

While making the changes, I was struggling with our decision to keep the `obs_names` / `var_names` separate from `obs` and `var`, because they are stored inside the `obs` and `var` and when making changes to the `obs` and `var` the first thing we do is throw it away.

By allowing the rownames of the `obs` and `var` to be the `obs_names` and `var_names`, the code did get simplified a lot.

---

```r
hdf5_write_compressed <- function(file, name, value, compression = c("none", "gzip", "lzf"), scalar = FALSE) {
  compression <- match.arg(compression)
  if (!is.null(dim(value))) {
    dims <- dim(value)
  } else {
    dims <- length(value)
  }
  dtype <- hdf5r::guess_dtype(value, scalar = scalar, string_len = Inf)
  space <- hdf5r::guess_space(value, dtype = dtype, chunked = FALSE)

  # TODO: lzf compression is not supported in hdf5r
  # TODO: allow the user to choose compression level
  gzip_level <- if (compression == "none") 0 else 9

  out <- file$create_dataset(
    name = name,
    dims = dims,
    gzip_level = gzip_level,
    robj = value,
    chunk_dims = NULL,
    space = space,
    dtype = dtype
  )
  # todo: create attr?

  out
}
```

----

There is currently an issue with the released version of hdf5r (hhoeflin/hdf5r#208) which was the cause of some of the strange errors in packages like MuDataSeurat. We already managed to fix the issue, but it still needs to be merged into the main branch and released.