### PR TITLE
return NULL if path does not exist

### DIFF
--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -49,7 +49,7 @@ read_h5ad_encoding <- function(file, name) {
 #'
 #' @noRd
 read_h5ad_element <- function(file, name, type = NULL, version = NULL, stop_on_error = FALSE, ...) {
-  if (!hdf5_path_exists(name)) {
+  if (!hdf5_path_exists(file, name)) {
     return(NULL)
   }
 

--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -49,6 +49,10 @@ read_h5ad_encoding <- function(file, name) {
 #'
 #' @noRd
 read_h5ad_element <- function(file, name, type = NULL, version = NULL, stop_on_error = FALSE, ...) {
+  if (!hdf5_path_exists(name)) {
+    return(NULL)
+  }
+
   if (is.null(type)) {
     encoding_list <- read_h5ad_encoding(file, name)
     type <- encoding_list$type


### PR DESCRIPTION
Without this, we get an error when reading an empty h5ad.

## Example

```python
import anndata as ad

adata = ad.AnnData(
  shape=(10, 20)
)

adata.write_h5ad("empty.h5ad")
```

```r
devtools::load_all()
adata <- read_h5ad("empty.h5ad")
```


    Error in `[[.H5File`(file, name) : 
      An object with name X does not exist in this group

## Testing

This situation will be covered by #193 by removing `X = ...` from the dummy_anndata generate_dataset call
