### PR TITLE
Fix AnnData initialisation when var is NULL

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -49,7 +49,7 @@ get_initial_var <- function(var, X, shape) {
   if (is.null(var)) {
     var <- data.frame(matrix(NA, nrow = shape[[2]], ncol = 0))
     if (!is.null(X)) {
-      colnames(var) <- colnames(X)
+      rownames(var) <- colnames(X)
     }
   }
   var

--- a/tests/testthat/test-InMemoryAnnData.R
+++ b/tests/testthat/test-InMemoryAnnData.R
@@ -40,6 +40,18 @@ test_that("with empty var", {
   expect_identical(ad$shape(), c(10L, 0L))
 })
 
+test_that("with only X, no obs or var", function() {
+  X <- dummy$X
+  dimnames(X) <- list(
+    rownames(dummy$obs),
+    rownames(dummy$var)
+  )
+  ad <- AnnData(X = X)
+  expect_identical(ad$shape(), c(10L, 20L))
+  expect_identical(ad$obs_names, rownames(dummy$obs))
+  expect_identical(ad$var_names, rownames(dummy$var))
+})
+
 # trackstatus: class=InMemoryAnnData, feature=test_get_layers, status=done
 test_that("'layers' works", {
   ## layers test helper function


### PR DESCRIPTION
Fixes #184

This PR fixes an issue when creating a new AnnData when X is defined but var is undefined.