### PR TITLE
Make `HDF5AnnData$finalize()` private

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,7 @@ Imports:
     Matrix,
     methods,
     purrr,
-    R6,
+    R6 (>= 2.4.0),
     rlang
 Suggests:
     anndata,

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -9,7 +9,15 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
   private = list(
     .h5obj = NULL,
     .close_on_finalize = FALSE,
-    .compression = NULL
+    .compression = NULL,
+
+    #' @description Close the HDF5 file when the object is garbage collected
+    finalize = function() {
+      if (private$.close_on_finalize) {
+        self$close()
+      }
+      return(invisible(self))
+    }
   ),
   active = list(
     #' @field X The X slot
@@ -352,14 +360,6 @@ HDF5AnnData <- R6::R6Class("HDF5AnnData", # nolint
           stop("uns must be NULL when loading an existing .h5ad file")
         }
       }
-    },
-
-    #' @description Close the HDF5 file when the object is garbage collected
-    finalize = function() {
-      if (private$.close_on_finalize) {
-        self$close()
-      }
-      return(invisible(self))
     },
 
     #' @description Close the HDF5 file


### PR DESCRIPTION
From v2.6.0 **{R6}** warns about public `finalize()` methods. This PR makes the method private and adds a version to the **{R6}** dependency.