### PR TITLE
Standardise styling

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@
 ^\.metals$
 ^\.vscode$
 ^\.lintr$
+^\.air.toml$
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$

--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,8 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+exclude = []
+default-exclude = true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,9 +23,12 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Install air
+        run: curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::lintr, local::.
+          extra-packages: any::lintr, any::styler, local::.
           needs: lint
 
       - name: Lint
@@ -33,3 +36,10 @@ jobs:
         shell: Rscript {0}
         env:
           LINTR_ERROR_ON_LINT: true
+
+      - name: Check code formatting
+        run: air format --check .
+
+      - name: Check vignette formatting
+        run: styler::style_dir("vignettes", dry = "fail")
+        shell: Rscript {0}

--- a/anndataR.Rproj
+++ b/anndataR.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 74a02069-5853-40a0-aa2f-7c3b8d406e45
 
 RestoreWorkspace: Default
 SaveWorkspace: Default
@@ -12,6 +13,7 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes
 
 BuildType: Package


### PR DESCRIPTION
Add some tools to help standardise styling:

- Add a check for code formatting using [`air`](https://www.tidyverse.org/blog/2025/02/air/) to the `lint` GitHub action
- Add an `air` config file
- Add a check for vignette code formatting using **{styler}** to the `lint` GitHub action
- Restyle the package

I have mainly `air` because it is fast and has some nicer (to me) defaults (especially for some function definitions). On the other hand, it is new so the styling might be a bit unstable while it is being developed. It also can't be used for `.Rmd` files which is why I have used **{styler}** to check those. I'm happy to switch to just **{styler}** if we think that is easier.

Side notes:

- Bioconductor styler is 4 space indentation so we might need to change to that at some point
- I read some pretty good arguments for why tab indentation is better than spaces for accessibility which I hadn't considered before. Not saying we should switch now, but just FYI.