### PR TITLE
Bugfix: assay.used attribute on Seurat graphs

### DIFF
--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -292,6 +292,7 @@ to_Seurat <- function(
     if (!is.null(obsp)) {
       dimnames(obsp) <- list(obs_names, obs_names)
       obsp_gr <- Seurat::as.Graph(obsp)
+      obsp_gr@assay.used <- assay_name
       obj[[paste0(assay_name, "_", graph_name)]] <- obsp_gr
     }
   }
@@ -1150,7 +1151,7 @@ from_Seurat <- function(
   for (graph_name in SeuratObject::Graphs(seurat_obj)) {
     graph <- seurat_obj@graphs[[graph_name]]
 
-    if (graph@assay.used != assay_name) {
+    if (!rlang::is_empty(graph@assay.used) && graph@assay.used != assay_name) {
       next
     }
 


### PR DESCRIPTION
This issue was made aware to me by @maartenciers

When converting a Seurat dataset that has graphs in it, not all graphs have the `assay.used` attribute set. 
If they haven't, `graph@assay.used` produces `character(0)`, leading to the error 
```Error in if (graph@assay.used != assay_name) { : 
  argument is of length zero
```

I've added a check so that we check for zero length arguments as well.

The same issue also cropped up when converting anndata to Seurat and then back to anndata, as we don't set this attribute in `to_Seurat`.
I propose that, if a graph gets converted and the `assay.used` attribute is not set, we set it with the `assay_name`.

Fixed issue:
```
> ad <- generate_dataset(n_obs = 10L, n_var = 20L, format = "AnnData")
> so1 <- to_Seurat(
    ad,
    graph_mapping = list(
      numeric_matrix = "numeric_matrix",
      integer_matrix = "integer_matrix"
    )
  )
> ad2 <- from_Seurat(so1, assay_name = "RNA", output_class = "InMemoryAnnData")
Error in if (graph@assay.used != assay_name) { : 
  argument is of length zero
```