### PR TITLE
Bugfix: assay_metadata issue when going AD -> Seurat -> AD -> Seurat

### DIFF
--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -292,6 +292,7 @@ to_Seurat <- function(
     if (!is.null(obsp)) {
       dimnames(obsp) <- list(obs_names, obs_names)
       obsp_gr <- Seurat::as.Graph(obsp)
+      obsp_gr@assay.used <- assay_name
       obj[[paste0(assay_name, "_", graph_name)]] <- obsp_gr
     }
   }
@@ -1150,7 +1151,7 @@ from_Seurat <- function(
   for (graph_name in SeuratObject::Graphs(seurat_obj)) {
     graph <- seurat_obj@graphs[[graph_name]]
 
-    if (graph@assay.used != assay_name) {
+    if (!rlang::is_empty(graph@assay.used) && graph@assay.used != assay_name) {
       next
     }
 

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -596,16 +596,11 @@ to_Seurat <- function(
 # nolint start: object_name_linter
 .to_Seurat_process_metadata <- function(adata, mapping, slot) {
   # nolint end: object_name_linter
-  # check if mapping contains all columns of slot
-  if (length(setdiff(names(adata[[slot]]), names(mapping))) == 0) {
-    adata[[slot]]
-  } else {
-    mapped <- lapply(seq_along(mapping), function(i) {
-      adata[[slot]][[mapping[[i]]]]
-    })
-    names(mapped) <- names(mapping)
-    as.data.frame(mapped)
-  }
+  mapped <- lapply(seq_along(mapping), function(i) {
+    adata[[slot]][[mapping[[i]]]]
+  })
+  names(mapped) <- names(mapping)
+  as.data.frame(mapped)
 }
 
 #' Convert a Seurat object to an AnnData object

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -194,7 +194,8 @@ to_Seurat <- function(
     assay_metadata_mapping,
     "var"
   )
-  if (!is.null(adata$var)) {
+
+  if (ncol(assay_metadata) != 0) {
     obj@assays[[assay_name]] <- SeuratObject::AddMetaData(
       obj@assays[[assay_name]],
       metadata = assay_metadata
@@ -596,11 +597,9 @@ to_Seurat <- function(
 # nolint start: object_name_linter
 .to_Seurat_process_metadata <- function(adata, mapping, slot) {
   # nolint end: object_name_linter
-  mapped <- lapply(seq_along(mapping), function(i) {
-    adata[[slot]][[mapping[[i]]]]
-  })
+  mapped <- adata[[slot]][unlist(mapping)]
   names(mapped) <- names(mapping)
-  as.data.frame(mapped)
+  mapped
 }
 
 #' Convert a Seurat object to an AnnData object
@@ -1034,26 +1033,29 @@ from_Seurat <- function(
 # nolint start: object_name_linter
 .from_Seurat_process_obs <- function(seurat_obj, assay_name, obs_mapping) {
   # nolint end: object_name_linter
-  obs <- data.frame(row.names = colnames(seurat_obj))
-
-  for (obs_name in names(obs_mapping)) {
-    obs[[obs_name]] <- seurat_obj[[obs_mapping[[obs_name]]]]
+  if (rlang::is_empty(obs_mapping)) {
+    return(data.frame(row.names = colnames(seurat_obj)))
   }
 
-  obs
+  mapped <- seurat_obj[[unlist(obs_mapping)]]
+  names(mapped) <- names(obs_mapping)
+
+  mapped
 }
 
 # nolint start: object_name_linter
 .from_Seurat_process_var <- function(seurat_obj, assay_name, var_mapping) {
   # nolint end: object_name_linter
   assay <- seurat_obj[[assay_name]]
-  var <- data.frame(row.names = rownames(seurat_obj))
 
-  for (var_name in names(var_mapping)) {
-    var[[var_name]] <- assay[[var_mapping[[var_name]]]]
+  if (rlang::is_empty(var_mapping)) {
+    return(data.frame(row.names = rownames(seurat_obj)))
   }
 
-  var
+  mapped <- assay[[unlist(var_mapping)]]
+  names(mapped) <- names(var_mapping)
+
+  mapped
 }
 
 # nolint start: object_name_linter object_length_linter

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -292,7 +292,9 @@ to_Seurat <- function(
     if (!is.null(obsp)) {
       dimnames(obsp) <- list(obs_names, obs_names)
       obsp_gr <- Seurat::as.Graph(obsp)
-      obsp_gr@assay.used <- assay_name
+      if (rlang::is_empty(obsp_gr@assay.used)) {
+        obsp_gr@assay.used <- assay_name
+      }
       obj[[paste0(assay_name, "_", graph_name)]] <- obsp_gr
     }
   }

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -185,7 +185,7 @@ for (obs_key in colnames(obj@meta.data)) {
     expect_true(obs_key %in% colnames(ad$obs))
     expect_equal(
       ad$obs[[obs_key]],
-      obj[[obs_key]],
+      obj@meta.data[[obs_key]],
       info = paste0("obs_key: ", obs_key)
     )
   })
@@ -204,7 +204,7 @@ for (var_key in colnames(active_assay@meta.data)) {
     skip_if(!is.null(msg), message = msg)
 
     expect_true(var_key %in% colnames(ad$var))
-    expect_equal(ad$var[[var_key]], active_assay[[var_key]])
+    expect_equal(ad$var[[var_key]], active_assay@meta.data[[var_key]])
   })
 }
 


### PR DESCRIPTION
When looking into #236 I encountered the following bug:

```{r}
> ad <- generate_dataset(n_obs = 10L, n_var = 20L, format = "AnnData")
> ad$var <- ad$var[c("factor", "logical")]

> so1 <- to_Seurat(
    ad,
    graph_mapping = list(
      numeric_matrix = "numeric_matrix",
      integer_matrix = "integer_matrix"
    )
  )

> ad2 <- from_Seurat(
    so1,
    assay_name = "RNA",
    output_class = "InMemoryAnnData",
    x_mapping = "counts"
  )
> so2 <- to_Seurat(ad2)
Error in names(v) <- row.names(value) : 
  'names' attribute [20] must be the same length as the vector [1]
```

This seems(?) to be due to rownames of the `ad$var` slot?

Fixed by not copying the whole slot.
