### PR TITLE
Allow v3 Assay objects in `from_Seurat()`

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -339,7 +339,7 @@ AbstractAnnData <- R6::R6Class(
               "], got [",
               paste(mat_dims, collapse = ", "),
               "]"
-            ),
+            )
           ),
           call = rlang::caller_env()
         )

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -925,7 +925,7 @@ from_Seurat <- function(
         }
 
         if (nrow(varm_data) != nrow(seurat_obj)) {
-          varm_str <- cli::cli_vec(varm, list("vec-last" = ",, "))
+          varm_str <- cli::cli_vec(varm, list("vec-last" = ",, ")) # nolint object_usage_linter
           cli_warn(paste(
             "Skipping {.code varm_mapping[[{i}]]} (c({.val {varm_str}}))",
             "because it does not contain data for every feature"

--- a/tests/testthat/test-Seurat.R
+++ b/tests/testthat/test-Seurat.R
@@ -314,3 +314,17 @@ test_that("from_Seurat retains connectivities", {
     ignore_attr = TRUE
   )
 })
+
+test_that("from_Seurat works with v3 Assays", {
+  obj_v3_assay <- obj
+  expect_warning(
+    obj_v3_assay[["RNA"]] <- as(Seurat::GetAssay(obj, "RNA"), "Assay")
+  )
+
+  adata_v3_assay <- from_Seurat(obj_v3_assay)
+
+  expect_identical(
+    t(adata_v3_assay$layers$counts),
+    SeuratObject::GetAssayData(obj_v3_assay, layer = "counts")
+  )
+})


### PR DESCRIPTION
Update `from_Seurat()` to handle v3 `Assay` objects:

- Remove checks for `Assay5` objects
- Add a check for the number of rows to `.from_Seurat_guess_varms()`
- Skip `varm` items if the number of rows doesn't match
- Update `Seurat` accessors
- Add a test for `Assay` objects

Fixes #203 