### PR TITLE
Add helper for styling vectors in messages

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -313,7 +313,7 @@ AbstractAnnData <- R6::R6Class(
     #   the name of a layer.
     # @param shape Expected dimensions of matrix
     # @param expected_rownames
-    # @param excepted_colnames
+    # @param expected_colnames
     .validate_aligned_array = function(
       mat,
       label,
@@ -339,47 +339,33 @@ AbstractAnnData <- R6::R6Class(
               "], got [",
               paste(mat_dims, collapse = ", "),
               "]"
-            ),
+            )
           ),
           call = rlang::caller_env()
         )
       }
-      if (!is.null(expected_rownames) & !has_row_names(mat)) {
+
+      if (!is.null(expected_rownames) & has_row_names(mat)) {
         if (!identical(rownames(mat), expected_rownames)) {
-          expected_str <- cli::cli_vec(
-            head(expected_rownames, 12),
-            list("vec-last" = ", ")
-          )
-          provided_str <- cli::cli_vec(
-            head(rownames(mat), 12),
-            list("vec-last" = ", ")
-          )
           cli_abort(
             c(
               "{.code rownames({label})} is not as expected",
-              "i" = "Expected row names: {.val {expected_str}}, ...",
-              "i" = "Provided row names: {.val {provided_str}}, ..."
+              "i" = "Expected row names: {style_vec(expected_colnames)}",
+              "i" = "Provided row names: {style_vec(rownames(mat))}"
             ),
             call = rlang::caller_env()
           )
         }
         rownames(mat) <- NULL
       }
+
       if (!is.null(expected_colnames) & !is.null(colnames(mat))) {
         if (!identical(colnames(mat), expected_colnames)) {
-          expected_str <- cli::cli_vec(
-            head(expected_colnames, 12),
-            list("vec-last" = ", ")
-          )
-          provided_str <- cli::cli_vec(
-            head(colnames(mat), 12),
-            list("vec-last" = ", ")
-          )
           cli_abort(
             c(
               "{.code colnames({label})} is not as expected",
-              "i" = "Expected column names: {.val {expected_str}}, ...",
-              "i" = "Provided column names: {.val {provided_str}}, ..."
+              "i" = "Expected column names: {style_vec(expected_colnames)}",
+              "i" = "Provided column names: {style_vec(colnames(mat))}"
             ),
             call = rlang::caller_env()
           )

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -236,14 +236,8 @@ to_Seurat <- function(
 
     reduction_fmt_msg <- paste(
       "Each item in {.arg reduction_mapping} must be a {.cls list}",
-      "with names {.val {keys_str}}"
+      "with names {style_vec(c('key', 'obsm', 'varm'), last = ' and (optionally) ')}"
     )
-    # nolint start object_usage_linter
-    keys_str <- cli::cli_vec(
-      c("key", "obsm", "varm"),
-      list("vec-last" = " and (optionally) ")
-    )
-    # nolint end
     for (i in seq_along(reduction_mapping)) {
       reduction_name <- names(reduction_mapping)[[i]]
       reduction <- reduction_mapping[[i]]
@@ -341,11 +335,10 @@ to_Seurat <- function(
     if (length(misc) == 2) {
       misc_key <- misc[[2]]
       if (!misc_key %in% names(misc_data)) {
-        misc_str <- cli::cli_vec(misc, list("vec-last" = ", ")) # nolint object_usage_linter
         cli_abort(paste(
           "The requested item {.code adata${misc_slot}[[{misc_key}]]}",
           "does not exist for {.code misc_mapping[[{i}]]}:",
-          "{.val misc_name} = c({.val {misc_str}})"
+          "{.val misc_name} = c({style_vec(misc)})"
         ))
       }
       misc_data <- misc_data[[misc_key]]

--- a/R/ui.R
+++ b/R/ui.R
@@ -1,0 +1,35 @@
+#' Style a vector
+#'
+#' Style a vector for use in **{cli}** calls
+#'
+#' @param x The vector to style
+#' @param last The separator before the last element in the vector
+#' @param trunc The maxium number of elements to show
+#' @param trunc_style The truncation style to use, either "both-ends"
+#'   (1, 2, ..., n-1, 1) or "head" (1, 2, 3, 4, ...)
+#' @param wrap Whether to wrap the output to appear as a vector, if `TRUE` then
+#' "c(1, 2, 3)" else "1, 2, 3"
+#'
+#' @returns A styled string that can be included directly using "{syle_vec(...)}"
+#' @noRd
+style_vec <- function(
+  x, last = ", ", trunc = 20L, trunc_style = c("both-ends", "head"), wrap = FALSE
+) {
+  trunc_style <- match.arg(trunc_style)
+
+  style <- list(
+    "vec-last" = last,
+    "vec-trunc" = trunc,
+    "vec-trunc-style" = trunc_style
+  )
+
+  x <- cli::cli_vec(x, style)
+
+  if (isTRUE(wrap)) {
+    x_str <- "c({.val {x}})"
+  } else {
+    x_str <- "{.val {x}}"
+  }
+
+  cli::cli_fmt(cli::cli_text(x_str))
+}

--- a/R/ui.R
+++ b/R/ui.R
@@ -13,7 +13,11 @@
 #' @returns A styled string that can be included directly using "{syle_vec(...)}"
 #' @noRd
 style_vec <- function(
-  x, last = ", ", trunc = 20L, trunc_style = c("both-ends", "head"), wrap = FALSE
+  x,
+  last = ", ",
+  trunc = 20L,
+  trunc_style = c("both-ends", "head"),
+  wrap = FALSE
 ) {
   trunc_style <- match.arg(trunc_style)
 


### PR DESCRIPTION
Improve the styling of vectors in error messages:

- Add a `style_vec()` function that can be reused (and makes the arguments more obvious)
- Replace previous uses of `cli::cli_vec()` with `style_vec()`