### PR TITLE
Pass messages instead of error objects to `cli_abort()`

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -339,7 +339,7 @@ AbstractAnnData <- R6::R6Class(
               "], got [",
               paste(mat_dims, collapse = ", "),
               "]"
-            ),
+            )
           ),
           call = rlang::caller_env()
         )

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -1025,7 +1025,7 @@ from_Seurat <- function(
       if (output_class == "HDF5AnnData") {
         on.exit(cleanup_HDF5AnnData(adata))
       }
-      cli_abort(e)
+      cli_abort(conditionMessage(e))
     }
   )
 }

--- a/R/SingleCellExperiment.R
+++ b/R/SingleCellExperiment.R
@@ -579,7 +579,7 @@ from_SingleCellExperiment <- function(
       if (output_class == "HDF5AnnData") {
         on.exit(cleanup_HDF5AnnData(adata))
       }
-      cli_abort(e)
+      cli_abort(conditionMessage(e))
     }
   )
 }


### PR DESCRIPTION
Fixes a mistake I introduced when updating the errors to use **{cli}** where `cli_abort()` is called on an error object instead of just a message leading to cryptic errors. Also fixes an extra comma which was making things even more confusing.

Fixes #242 