### PR TITLE
Refactor hdf5r constructor

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -10,6 +10,18 @@
   )
 }
 
+.anndata_slots <- c(
+  "X",
+  "obs",
+  "var",
+  "uns",
+  "obsm",
+  "varm",
+  "layers",
+  "obsp",
+  "varp"
+)
+
 #' @title Abstract AnnData class
 #'
 #' @description
@@ -108,16 +120,7 @@ AbstractAnnData <- R6::R6Class(
         sep = ""
       )
 
-      for (attribute in c(
-        "obs",
-        "var",
-        "uns",
-        "obsm",
-        "varm",
-        "layers",
-        "obsp",
-        "varp"
-      )) {
+      for (attribute in .anndata_slots[-1]) {
         key_fun <- self[[paste0(attribute, "_keys")]]
         keys <-
           if (!is.null(key_fun)) {

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -322,7 +322,10 @@ HDF5AnnData <- R6::R6Class(
 
       # detect file mode
       is_readonly <- file$get_intent() == "H5F_ACC_RDONLY"
-      is_empty <- !"encoding-type" %in% hdf5r::h5attributes(file)
+      is_empty <- length(hdf5r::list.groups(file)) == 0L &&
+        length(hdf5r::list.datasets(file)) == 0L &&
+        length(hdf5r::list.attributes(file)) == 0L &&
+        length(hdf5r::list.objects(file)) == 0L
 
       if (!is_readonly) {
         if (!is_empty) {

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -288,9 +288,9 @@ HDF5AnnData <- R6::R6Class(
         if (!file.exists(file) && mode %in% c("r", "r+")) {
           cli_abort(
             paste(
-              "File {.arg {file}} does not exist but mode is set to {.arg {mode}}.",
+              "File {.file {file}} does not exist but mode is set to {.val {mode}}.",
               "If you want to create a new file, use a different mode (e.g. 'w-').",
-              "See {.fun read_h5ad} or {.fun write_h5ad} for more information."
+              "See {.help read_h5ad} or {.help write_h5ad} for more information."
             ),
             call = rlang::caller_env()
           )
@@ -299,9 +299,9 @@ HDF5AnnData <- R6::R6Class(
         if (file.exists(file) && mode %in% c("w-", "x")) {
           cli_abort(
             paste(
-              "File {.arg {file}} already exists but mode is set to {.arg {mode}}.",
+              "File {.file {file}} does not exist but mode is set to {.val {mode}}.",
               "If you want to overwrite the file, use a different mode (e.g. 'w').",
-              "See {.fun read_h5ad} or {.fun write_h5ad} for more information."
+              "See {.help read_h5ad} or {.help write_h5ad} for more information."
             ),
             call = rlang::caller_env()
           )
@@ -345,7 +345,7 @@ HDF5AnnData <- R6::R6Class(
       attrs <- hdf5r::h5attributes(file)
       if (!all(c("encoding-type", "encoding-version") %in% names(attrs))) {
         cli_abort(c(
-          "File {.arg {file}} is not a valid H5AD file.",
+          "File {.file {file}} is not a valid H5AD file.",
           i = "Either the file is not an H5AD file or it was created with {.pkg anndata<0.8.0}."
         ))
       }
@@ -361,7 +361,7 @@ HDF5AnnData <- R6::R6Class(
             paste0(
               "Error trying to write data (",
               paste(.anndata_slots[!are_null], collapse = ", "),
-              ") to an h5ad file opened in read-only mode."
+              ") to an H5AD file opened in read-only mode."
             )
           )
         }

--- a/R/Seurat.R
+++ b/R/Seurat.R
@@ -317,22 +317,11 @@ to_Seurat <- function(
 
     misc_slot <- misc[1]
     misc_key <- misc[2]
-    expected_slots <- c(
-      "X",
-      "layers",
-      "obs",
-      "obsm",
-      "obsp",
-      "var",
-      "varm",
-      "varp",
-      "uns"
-    )
-    if (!misc_slot %in% expected_slots) {
+    if (!misc_slot %in% .anndata_slots) {
       cli_abort(c(
         paste(
           "The first element in each item of {.arg misc_mapping}",
-          "must be one of: {.or {.val {expected_slots}}}"
+          "must be one of: {.or {.val {anndata_slots}}}"
         ),
         "i" = "{.code misc_mapping[[{i}]][1]}: {.val {misc_slot}}"
       ))

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -636,8 +636,8 @@ write_h5ad_data_frame <- function(
 write_empty_h5ad <- function(file, obs, var, compression, version = "0.1.0") {
   write_h5ad_encoding(file, "/", "anndata", "0.1.0")
 
-  write_h5ad_element(obs, file, "/obs", compression)
-  write_h5ad_element(var, file, "/var", compression)
+  write_h5ad_element(obs[, integer(0)], file, "/obs", compression)
+  write_h5ad_element(var[, integer(0)], file, "/var", compression)
 
   file$create_group("layers")
   write_h5ad_encoding(file, "/layers", "dict", "0.1.0")

--- a/tests/testthat/test-HDF5AnnData.R
+++ b/tests/testthat/test-HDF5AnnData.R
@@ -148,7 +148,7 @@ test_that("reading var names works", {
 # SETTERS ----------------------------------------------------------------
 test_that("creating empty H5AD works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
-  expect_silent(HDF5AnnData$new(h5ad_file))
+  expect_silent(HDF5AnnData$new(file = h5ad_file, mode = "w-"))
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_X, status=done
@@ -156,7 +156,7 @@ test_that("writing X works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
   obs <- data.frame(row.names = 1:10)
   var <- data.frame(row.names = 1:20)
-  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var, mode = "w-")
 
   X <- matrix(rnorm(10 * 20), nrow = 10, ncol = 20)
   expect_silent(h5ad$X <- X)
@@ -167,7 +167,7 @@ test_that("writing layers works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
   obs <- data.frame(row.names = 1:10)
   var <- data.frame(row.names = 1:20)
-  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var, mode = "w-")
 
   X <- matrix(rnorm(10 * 20), nrow = 10, ncol = 20)
   expect_silent(h5ad$layers <- list(layer1 = X, layer2 = X))
@@ -178,7 +178,7 @@ test_that("writing obs works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
   obs <- data.frame(row.names = 1:10)
   var <- data.frame(row.names = 1:20)
-  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var, mode = "w-")
 
   obs <- data.frame(
     Letters = LETTERS[1:10],
@@ -194,7 +194,7 @@ test_that("writing var works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
   obs <- data.frame(row.names = 1:10)
   var <- data.frame(row.names = 1:20)
-  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var, mode = "w-")
 
   var <- data.frame(
     Letters = LETTERS[1:20],
@@ -210,7 +210,7 @@ test_that("writing obs names works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
   obs <- data.frame(row.names = 1:10)
   var <- data.frame(row.names = 1:20)
-  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var, mode = "w-")
 
   h5ad$obs_names <- LETTERS[1:10]
   expect_identical(h5ad$obs_names, LETTERS[1:10])
@@ -221,7 +221,7 @@ test_that("writing var names works", {
   h5ad_file <- withr::local_tempfile(fileext = ".h5ad")
   obs <- data.frame(row.names = 1:10)
   var <- data.frame(row.names = 1:20)
-  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
+  h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var, mode = "w-")
 
   h5ad$var_names <- LETTERS[1:20]
   expect_identical(h5ad$var_names, LETTERS[1:20])

--- a/tests/testthat/test-generate_dataset.R
+++ b/tests/testthat/test-generate_dataset.R
@@ -3,7 +3,7 @@ test_that("generating dummy data works", {
   expect_type(dataset, "list")
   expect_setequal(
     names(dataset),
-    c("X", "obs", "obsp", "obsm", "var", "varp", "varm", "layers", "uns")
+    .anndata_slots
   )
   expect_identical(dim(dataset$X), c(10L, 20L))
 })


### PR DESCRIPTION
This PR refactors the way HDF5AnnData resolves characters to H5File.

Solves #121 and #206

### Summary by copilot

This constructor handles either connecting to an existing .h5ad file or creating a new one. Its implementation follows a logical sequence:

1. Dependencies and Arguments Validation:

    * Ensures the hdf5r package is available
    * Validates compression and file opening mode arguments
    * Stores the compression setting for future operations
    * Sets a flag to close the file when the object is garbage collected (if file was provided as a path)
3. File Opening and Existence Checks:
    * For path inputs: validates file existence against the specified mode (e.g., prevents opening non-existent files in read mode)
    * Converts the file path to an hdf5r::H5File object
    * Ensures the file parameter is a valid H5File object
4. File State Analysis:
    * Determines if the file is read-only
    * Checks if the file is empty (lacks the "encoding-type" attribute)
5. File Initialization:
    * For writable empty files: initializes AnnData structure with proper shape and observation/variable metadata
    * For existing writable files: warns about potential data corruption risks
6. H5AD Format Validation:
    * Verifies the file has required H5AD attributes
    * Reports helpful error messages for invalid files
7. Data Population:
    * For read-only files: prevents any attempts to write data
    * For writable files: writes any provided data slots (X, obs, var, layers, etc.) to the file

