### PR TITLE
Use PAT in pr-commands workflow

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,15 +14,17 @@ jobs:
     name: document
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GTHB_PAT }}
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GTHB_PAT }}
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -42,26 +44,28 @@ jobs:
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add man/\* NAMESPACE
-          git commit -m 'Document'
+          git commit -m 'Document (GHA)'
 
       - uses: r-lib/actions/pr-push@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GTHB_PAT }}
 
   style:
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR') && startsWith(github.event.comment.body, '/style') }}
     name: style
     runs-on: ubuntu-latest
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GTHB_PAT }}
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GTHB_PAT }}
 
       - uses: r-lib/actions/setup-r@v2
 
@@ -95,4 +99,4 @@ jobs:
 
       - uses: r-lib/actions/pr-push@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GTHB_PAT }}


### PR DESCRIPTION
Currently, the PR commands work and update a PR but the checks are not rerun because that is specifically prohibited when using the default `GITHUB_TOKEN`. This is inconvenient because you can't see if styling etc. worked until something happens to force the checks to run. Switching to a PAT should (hopefully) trigger the checks as for a normal commit.