### PR TITLE
Change sapply to vapply

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: anndataR
 Title: AnnData interoperability in R
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: c(
     person("Robrecht", "Cannoodt", , "robrecht@data-intuitive.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # anndataR 0.1.0.9001
 
-- remove anndataR.Rproj from repository
+- change uses of `sapply` to `vapply`
 
 # anndataR 0.1.0 (inital release candidate)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# anndataR 0.1.0.9001
+
+- remove anndataR.Rproj from repository
+
 # anndataR 0.1.0 (inital release candidate)
 
 Initial release candidate of **{anndataR}** including:

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -355,7 +355,11 @@ HDF5AnnData <- R6::R6Class(
 
       if (is_readonly) {
         # if any of these variables are not NULL, throw an error
-        are_null <- vapply(.anndata_slots, function(x) is.null(get(x)), logical(1))
+        are_null <- vapply(
+          .anndata_slots,
+          function(x) is.null(get(x)),
+          logical(1)
+        )
         if (!all(are_null)) {
           cli_abort(
             paste0(

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -355,7 +355,7 @@ HDF5AnnData <- R6::R6Class(
 
       if (is_readonly) {
         # if any of these variables are not NULL, throw an error
-        are_null <- sapply(.anndata_slots, function(x) is.null(get(x)))
+        are_null <- vapply(.anndata_slots, function(x) is.null(get(x)), logical(1))
         if (!all(are_null)) {
           cli_abort(
             paste0(

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -115,7 +115,7 @@ for (name in test_names) {
   skip_if_no_h5diff()
   # Get all R datatypes that are equivalent to the python datatype (name)
   res <- Filter(function(x) x[[1]] == name, matrix_equivalences)
-  r_datatypes <- sapply(res, function(x) x[[2]])
+  r_datatypes <- vapply(res, function(x) x[[2]], character(1))
 
   for (r_name in r_datatypes) {
     test_msg <- paste0(

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -129,7 +129,7 @@ for (name in test_names) {
   skip_if_no_h5diff()
   # Get all R datatypes that are equivalent to the python datatype (name)
   res <- Filter(function(x) x[[1]] == name, matrix_equivalences)
-  r_datatypes <- sapply(res, function(x) x[[2]])
+  r_datatypes <- vapply(res, function(x) x[[2]], character(1))
 
   for (r_name in r_datatypes) {
     test_msg <- paste0(

--- a/tests/testthat/test-roundtrip-obsmvarm.R
+++ b/tests/testthat/test-roundtrip-obsmvarm.R
@@ -169,7 +169,7 @@ for (name in test_names) {
   skip_if_no_h5diff()
   # Get all R datatypes that are equivalent to the python datatype (name)
   res <- Filter(function(x) x[[1]] == name, all_equivalences)
-  r_datatypes <- sapply(res, function(x) x[[2]])
+  r_datatypes <- vapply(res, function(x) x[[2]], character(1))
 
   for (r_name in r_datatypes) {
     test_msg <- paste0(

--- a/tests/testthat/test-roundtrip-obspvarp.R
+++ b/tests/testthat/test-roundtrip-obspvarp.R
@@ -152,7 +152,7 @@ for (name in test_names) {
   skip_if_no_h5diff()
   # Get all R datatypes that are equivalent to the python datatype (name)
   res <- Filter(function(x) x[[1]] == name, matrix_equivalences)
-  r_datatypes <- sapply(res, function(x) x[[2]])
+  r_datatypes <- vapply(res, function(x) x[[2]], character(1))
 
   for (r_name in r_datatypes) {
     test_msg <- paste0(

--- a/tests/testthat/test-roundtrip-obsvar.R
+++ b/tests/testthat/test-roundtrip-obsvar.R
@@ -140,7 +140,7 @@ for (name in test_names) {
   skip_if_no_h5diff()
   # Get all R datatypes that are equivalent to the python datatype (name)
   res <- Filter(function(x) x[[1]] == name, vector_equivalences)
-  r_datatypes <- sapply(res, function(x) x[[2]])
+  r_datatypes <- vapply(res, function(x) x[[2]], character(1))
 
   for (r_name in r_datatypes) {
     test_msg <- paste0(

--- a/vignettes/development_status.Rmd
+++ b/vignettes/development_status.Rmd
@@ -32,7 +32,7 @@ status_lines <- map_df(source, function(path) {
         line_stripped <- gsub(" *# trackstatus: *", "", lines[[line_number]])
         line_split <- str_split_1(line_stripped, ", *")
         vals_split <- str_split(line_split, " *= *")
-        names <- sapply(vals_split, function(x) x[[1]])
+        names <- vapply(vals_split, function(x) x[[1]], character(1))
         values <- lapply(vals_split, function(x) x[[2]])
         df <- data.frame(setNames(values, names), check.names = FALSE)
         df$source_file <- path


### PR DESCRIPTION
**Related to:** #275 and #293 

## Description

Most uses of sapply happened in the roundtrip tests. When running them, they failed due to invalidated file ids. Some gc() fixed this in #293, but I presume they're not being ran in the github actions.

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [x] Add/update tests
- [x] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
