### PR TITLE
Fixes for compatibility with `anndata>=0.12.0`

### DIFF
--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -64,6 +64,7 @@ read_h5ad_element <- function(
 
   read_fun <- switch(
     type,
+    "null" = read_h5ad_null,
     "array" = read_h5ad_dense_array,
     "rec-array" = read_h5ad_rec_array,
     "csr_matrix" = read_h5ad_csr_matrix,
@@ -100,6 +101,22 @@ read_h5ad_element <- function(
   )
 }
 
+#' Read H5AD null
+#'
+#' Read a null value from an H5AD file
+#'
+#' @param file Path to a H5AD file or an open H5AD handle
+#' @param name Name of the element within the H5AD file
+#' @param version Encoding version of the element to read
+#'
+#' @return `NULL`
+#' @noRd
+read_h5ad_null <- function(file, name, version = "0.1.0") {
+  version <- match.arg(version)
+
+  NULL
+}
+
 #' Read H5AD dense array
 #'
 #' Read a dense array from an H5AD file
@@ -122,7 +139,7 @@ read_h5ad_dense_array <- function(file, name, version = "0.2.0") {
     dim(data) <- length(data)
   }
 
-  # transpose the matrix if need be
+  # Transpose the matrix if need be
   if (is.matrix(data)) {
     data <- t(data)
   } else if (is.array(data) && length(dim(data)) > 1) {
@@ -131,8 +148,9 @@ read_h5ad_dense_array <- function(file, name, version = "0.2.0") {
 
   # Reverse {rhdf5} coercion to factors
   if (is.factor(data) && all(levels(data) %in% c("TRUE", "FALSE"))) {
+    dims <- dim(data)
     data <- as.logical(data)
-    dim(data) <- length(data)
+    dim(data) <- dims
   }
 
   data

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -394,6 +394,14 @@ write_h5ad_string_array <- function(
   compression,
   version = "0.2.0"
 ) {
+  if (!is.vector(value)) {
+    if (is.matrix(value)) {
+      value <- t(value)
+    } else if (is.array(value)) {
+      value <- aperm(value)
+    }
+  }
+
   hdf5_write_dataset(
     file = file,
     name = name,

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -7,7 +7,7 @@
 #' Write an element to an H5AD file
 #'
 #' @param value The value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -31,11 +31,11 @@ write_h5ad_element <- function(
 ) {
   compression <- match.arg(compression)
 
-  # cli::cli_alert_info("Writing {.path {name}} with {.pkg rhdf5}")
-
   # Sparse matrices
   write_fun <-
-    if (inherits(value, "sparseMatrix")) {
+    if (is.null(value)) {
+      write_h5ad_null
+    } else if (inherits(value, "sparseMatrix")) {
       # Sparse matrices
       write_h5ad_sparse_array
     } else if (is.factor(value)) {
@@ -148,12 +148,38 @@ write_h5ad_encoding <- function(file, name, encoding, version) {
   )
 }
 
+#' Write H5AD null
+#'
+#' Write a null dataset to an H5AD file
+#'
+#' @param value Value to write, not used
+#' @param file An open H5AD handle
+#' @param name Name of the element within the H5AD file
+#' @param compression Not used as there is no value
+#' @param version Encoding version of the element to write
+#'
+#' @noRd
+write_h5ad_null <- function(value, file, name, compression, version = "0.1.0") {
+  h5s <- rhdf5::H5Screate("H5S_NULL")
+  on.exit(rhdf5::H5Sclose(h5s), add = TRUE)
+
+  h5d <- rhdf5::H5Dcreate(
+    file,
+    name = name,
+    dtype_id = "H5T_IEEE_F32LE",
+    h5space = h5s
+  )
+  on.exit(rhdf5::H5Dclose(h5d), add = TRUE)
+
+  write_h5ad_encoding(file, name, "null", version)
+}
+
 #' Write H5AD dense array
 #'
 #' Write a dense array to an H5AD file
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -222,7 +248,7 @@ write_h5ad_dense_array <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -295,7 +321,7 @@ write_h5ad_sparse_array <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -339,7 +365,7 @@ write_h5ad_nullable_boolean <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -382,7 +408,7 @@ write_h5ad_nullable_integer <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -419,7 +445,7 @@ write_h5ad_string_array <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -475,7 +501,7 @@ write_h5ad_categorical <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -504,7 +530,7 @@ write_h5ad_string_scalar <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -543,7 +569,7 @@ write_h5ad_numeric_scalar <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
@@ -577,7 +603,7 @@ write_h5ad_mapping <- function(
 #' @noRd
 #'
 #' @param value Value to write
-#' @param file Path to a H5AD file or an open H5AD handle
+#' @param file An open H5AD handle
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -160,6 +160,10 @@ write_h5ad_encoding <- function(file, name, encoding, version) {
 #'
 #' @noRd
 write_h5ad_null <- function(value, file, name, compression, version = "0.1.0") {
+  if (isFALSE(getOption("anndataR.write_null", "TRUE"))) {
+    return(invisible(NULL))
+  }
+
   h5s <- rhdf5::H5Screate("H5S_NULL")
   on.exit(rhdf5::H5Sclose(h5s), add = TRUE)
 

--- a/tests/testthat/helper-skip_if_no_anndata.R
+++ b/tests/testthat/helper-skip_if_no_anndata.R
@@ -4,7 +4,7 @@ skip_if_no_anndata <- function() {
   testthat::skip_if_not_installed("reticulate")
   testthat::skip_if_not_installed("anndata")
   requireNamespace("reticulate")
-  reticulate::py_require("anndata<=0.11.4")
+  reticulate::py_require("anndata")
   testthat::skip_if_not(
     reticulate::py_module_available("anndata"),
     message = "Python anndata module not available for testing"

--- a/tests/testthat/test-roundtrip-uns-nested.R
+++ b/tests/testthat/test-roundtrip-uns-nested.R
@@ -54,13 +54,9 @@ for (name in test_names) {
     skip_if(!is.null(msg), message = msg)
 
     adata_r <- read_h5ad(file_py, as = "HDF5AnnData")
-    nested_keys <- if (name == "none") {
-      list()
-    } else {
-      names(adata_r$uns$nested)
-    }
+
     expect_equal(
-      nested_keys,
+      names(adata_r$uns$nested),
       bi$list(adata_py$uns$nested$keys())
     )
 

--- a/tests/testthat/test-roundtrip-uns-nested.R
+++ b/tests/testthat/test-roundtrip-uns-nested.R
@@ -97,8 +97,6 @@ for (name in test_names) {
   gc()
 
   test_that(paste0("Writing an AnnData with uns_nested '", name, "' works"), {
-    skip_if(name == "none", message = "No value to test for 'none'")
-
     msg <- message_if_known(
       backend = "HDF5AnnData",
       slot = c("uns_nested"),

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -70,7 +70,6 @@ for (name in test_names) {
   test_that(
     paste0("Comparing an anndata with uns '", name, "' with reticulate works"),
     {
-      skip_if(name == "none", message = "No value to test for 'none'")
       msg <- message_if_known(
         backend = "HDF5AnnData",
         slot = c("uns"),
@@ -94,8 +93,6 @@ for (name in test_names) {
   gc()
 
   test_that(paste0("Writing an AnnData with uns '", name, "' works"), {
-    skip_if(name == "none", message = "No value to test for 'none'")
-
     msg <- message_if_known(
       backend = "HDF5AnnData",
       slot = c("uns"),

--- a/tests/testthat/test-roundtrip-uns.R
+++ b/tests/testthat/test-roundtrip-uns.R
@@ -54,13 +54,9 @@ for (name in test_names) {
     skip_if(!is.null(msg), message = msg)
 
     adata_r <- read_h5ad(file_py, as = "HDF5AnnData")
-    uns_keys <- if (name == "none") {
-      list()
-    } else {
-      names(adata_r$uns)
-    }
+
     expect_equal(
-      uns_keys,
+      names(adata_r$uns),
       bi$list(adata_py$uns$keys())
     )
 


### PR DESCRIPTION
**Related to:** Fixes #304 

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Minor changes for compatibility with `anndata>=0.12.0` (see https://github.com/scverse/anndata/issues/2052):

- Unpin the version of `anndata` used for tests to test against latest version
- Add a `read_h5ad_null()` helper function
- Add a `write_h5ad_null()` helper function
  - Setting `option(anndataR.write_null = FALSE)` disables writing `NULL` values for compatibility with reading using `anndata<0.12.0`
- Fix a bug in `write_h5ad_string_array()` where values were not transposed correctly
- Properly conserve dimensions in `read_h5ad_dense_array()`
- Remove workarounds and skipping of `none` values in roundtrip tests

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
