### PR TITLE
Refactor obs/var_names handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # anndataR unreleased
 
+## Major changes
+
+- Refactor obs/var_names handling for improved data consistency (PR #328)
+  - `InMemoryAnnData` now stores `obs_names` and `var_names` as separate private fields instead of relying on rownames of `obs`/`var` data.frames
+  - `HDF5AnnData` maintains separate obs/var names management to ensure consistency between obs/var data.frames and dimnames
+  - All matrix data (`X`, `layers`, `obsm`, `varm`, `obsp`, `varp`) is now stored internally **without** dimnames for consistency
+  - Dimnames are added **on-the-fly** when users access data, ensuring proper obs/var name display
+
 ## Minor changes
 
 - Refactor setter methods in `HDF5AnnData` and `InMemoryAnnData` to use pipe 
@@ -16,6 +24,10 @@
   indirect S3 methods `rownames` and `colnames` (PR #328)
 - Fix error message variable name in `.validate_aligned_array()` method 
   (expected_colnames → expected_rownames) (PR #328)
+- Fix Seurat conversion for PCA loadings with variable feature subsets (PR #328)
+  - Seurat PCA loadings only contain variable features, not all genes
+  - Now properly expands loadings matrix to include all genes with zeros for non-variable features
+  - Adds warning when rownames don't match var_names during conversion
 
 # anndataR 0.99.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,22 @@
+# anndataR unreleased
+
+## Minor changes
+
+- Refactor setter methods in `HDF5AnnData` and `InMemoryAnnData` to use pipe 
+  operators for cleaner code (PR #328)
+- Add explanatory comments for matrix generation alignment with dummy-anndata 
+  (PR #328)
+
+
+## Bug fixes
+
+- Add compression parameter to additional write operations in `HDF5AnnData` 
+  for consistency (PR #328)
+- Directly use `obs_names` and `var_names` properties instead of corresponding
+  indirect S3 methods `rownames` and `colnames` (PR #328)
+- Fix error message variable name in `.validate_aligned_array()` method 
+  (expected_colnames → expected_rownames) (PR #328)
+
 # anndataR 0.99.2
 
 * Add `@return` to R6 object man pages to address **{BiocCheck}** warning (PR #319)

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -306,7 +306,9 @@ AbstractAnnData <- R6::R6Class(
       label,
       shape,
       expected_rownames = NULL,
-      expected_colnames = NULL
+      expected_colnames = NULL,
+      strip_rownames = TRUE,
+      strip_colnames = TRUE
     ) {
       if (is.null(mat)) {
         return(mat)
@@ -343,6 +345,9 @@ AbstractAnnData <- R6::R6Class(
             call = rlang::caller_env()
           )
         }
+      }
+      # Strip rownames for storage if requested
+      if (strip_rownames) {
         rownames(mat) <- NULL
       }
 
@@ -357,6 +362,9 @@ AbstractAnnData <- R6::R6Class(
             call = rlang::caller_env()
           )
         }
+      }
+      # Strip colnames for storage if requested
+      if (strip_colnames) {
         colnames(mat) <- NULL
       }
 
@@ -376,7 +384,9 @@ AbstractAnnData <- R6::R6Class(
       label,
       shape,
       expected_rownames = NULL,
-      expected_colnames = NULL
+      expected_colnames = NULL,
+      strip_rownames = TRUE,
+      strip_colnames = TRUE
     ) {
       if (is.null(collection)) {
         return(collection)
@@ -387,12 +397,14 @@ AbstractAnnData <- R6::R6Class(
 
       for (mtx_name in collection_names) {
         collection_name <- paste0(label, "[['", mtx_name, "']]")
-        private$.validate_aligned_array(
+        collection[[mtx_name]] <- private$.validate_aligned_array(
           collection[[mtx_name]],
           collection_name,
           shape = shape,
           expected_rownames = expected_rownames,
-          expected_colnames = expected_colnames
+          expected_colnames = expected_colnames,
+          strip_rownames = strip_rownames,
+          strip_colnames = strip_colnames
         )
       }
 
@@ -492,6 +504,92 @@ AbstractAnnData <- R6::R6Class(
       }
 
       names
+    },
+
+    # @description Add dimnames to matrices/data.frames for user access
+    # @param mat A matrix or data.frame to add dimnames to
+    # @param slot_type The type of slot: "X", "layers", "obsm", "varm", "obsp", "varp"
+    .add_matrix_dimnames = function(
+      mat,
+      slot_type = c("X", "layers", "obsm", "varm", "obsp", "varp")
+    ) {
+      if (is.null(mat)) {
+        return(mat)
+      }
+
+      slot_type <- match.arg(slot_type)
+
+      switch(
+        slot_type,
+        "X" = {
+          dimnames(mat) <- list(self$obs_names, self$var_names)
+        },
+        "layers" = {
+          dimnames(mat) <- list(self$obs_names, self$var_names)
+        },
+        "obsm" = {
+          rownames(mat) <- self$obs_names
+        },
+        "varm" = {
+          rownames(mat) <- self$var_names
+        },
+        "obsp" = {
+          dimnames(mat) <- list(self$obs_names, self$obs_names)
+        },
+        "varp" = {
+          dimnames(mat) <- list(self$var_names, self$var_names)
+        }
+      )
+
+      mat
+    },
+
+    # @description Add dimnames to mapping lists (obsm, varm, obsp, varp, layers)
+    # @param mapping_list A named list of matrices to add dimnames to
+    # @param slot_type The type of slot: "layers", "obsm", "varm", "obsp", "varp"
+    .add_mapping_dimnames = function(
+      mapping_list,
+      slot_type = c("layers", "obsm", "varm", "obsp", "varp")
+    ) {
+      if (is.null(mapping_list)) {
+        return(mapping_list)
+      }
+
+      slot_type <- match.arg(slot_type)
+
+      for (i in seq_along(mapping_list)) {
+        if (!is.null(mapping_list[[i]])) {
+          mapping_list[[i]] <- private$.add_matrix_dimnames(
+            mapping_list[[i]],
+            slot_type
+          )
+        }
+      }
+
+      mapping_list
+    },
+
+    # @description Add rownames to obs/var data.frames
+    # @param df A data.frame to add rownames to
+    # @param slot_type The type of slot: "obs" or "var"
+    .add_obsvar_dimnames = function(df, slot_type = c("obs", "var")) {
+      if (is.null(df)) {
+        return(df)
+      }
+
+      slot_type <- match.arg(slot_type)
+
+      switch(
+        slot_type,
+        "obs" = {
+          rownames(df) <- self$obs_names
+        },
+        "var" = {
+          rownames(df) <- self$var_names
+        }
+      )
+
+      df
     }
   )
 )

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -337,7 +337,7 @@ AbstractAnnData <- R6::R6Class(
           cli_abort(
             c(
               "{.code rownames({label})} is not as expected",
-              "i" = "Expected row names: {style_vec(expected_colnames)}",
+              "i" = "Expected row names: {style_vec(expected_rownames)}",
               "i" = "Provided row names: {style_vec(rownames(mat))}"
             ),
             call = rlang::caller_env()

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -47,19 +47,18 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "X")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_X, status=done
-        value <- private$.validate_aligned_array(
+        private$.validate_aligned_array(
           value,
           "X",
           shape = c(self$n_obs(), self$n_vars()),
           expected_rownames = self$obs_names,
           expected_colnames = self$var_names
-        )
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "X",
-          private$.compression
-        )
+        ) |>
+          write_h5ad_element(
+            private$.h5obj,
+            "X",
+            private$.compression
+          )
       }
     },
     #' @field layers See [AnnData-usage]
@@ -71,19 +70,18 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "layers")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_layers, status=done
-        value <- private$.validate_aligned_mapping(
+        private$.validate_aligned_mapping(
           value,
           "layers",
           c(self$n_obs(), self$n_vars()),
           expected_rownames = self$obs_names,
           expected_colnames = self$var_names
-        )
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "layers",
-          private$.compression
-        )
+        ) |>
+          write_h5ad_element(
+            private$.h5obj,
+            "layers",
+            private$.compression
+          )
       }
     },
     #' @field obsm See [AnnData-usage]
@@ -95,18 +93,16 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "obsm")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_obsm, status=done
-        value <- private$.validate_aligned_mapping(
-          value,
+        private$.validate_aligned_mapping(
           "obsm",
           c(self$n_obs()),
           expected_rownames = self$obs_names
-        )
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "obsm",
-          private$.compression
-        )
+        ) |>
+          write_h5ad_element(
+            private$.h5obj,
+            "obsm",
+            private$.compression
+          )
       }
     },
     #' @field varm See [AnnData-usage]
@@ -118,18 +114,17 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "varm")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_varm, status=done
-        value <- private$.validate_aligned_mapping(
+        private$.validate_aligned_mapping(
           value,
           "varm",
           c(self$n_vars()),
           expected_rownames = self$var_names
-        )
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "varm",
-          private$.compression
-        )
+        ) |>
+          write_h5ad_element(
+            private$.h5obj,
+            "varm",
+            private$.compression
+          )
       }
     },
     #' @field obsp See [AnnData-usage]
@@ -141,18 +136,17 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "obsp")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_obsp, status=done
-        value <- private$.validate_aligned_mapping(
+        private$.validate_aligned_mapping(
           value,
           "obsp",
           c(self$n_obs(), self$n_obs()),
           expected_rownames = self$obs_names,
           expected_colnames = self$obs_names
-        )
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "obsp",
-          private$.compression
+        ) |>
+          write_h5ad_element(
+            private$.h5obj,
+            "obsp",
+            private$.compression
         )
       }
     },
@@ -165,19 +159,18 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "varp")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_varp, status=done
-        value <- private$.validate_aligned_mapping(
+        private$.validate_aligned_mapping(
           value,
           "varp",
           c(self$n_vars(), self$n_vars()),
           expected_rownames = self$var_names,
           expected_colnames = self$var_names
-        )
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "varp",
-          private$.compression
-        )
+        ) |>
+          write_h5ad_element(
+            private$.h5obj,
+            "varp",
+            private$.compression
+          )
       }
     },
     #' @field obs See [AnnData-usage]
@@ -189,13 +182,12 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "obs")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_obs, status=done
-        value <- private$.validate_obsvar_dataframe(value, "obs")
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "obs",
-          private$.compression
-        )
+        private$.validate_obsvar_dataframe(value, "obs") |>
+          write_h5ad_element(
+            private$.h5obj,
+            "obs",
+            private$.compression
+          )
       }
     },
     #' @field var See [AnnData-usage]
@@ -207,13 +199,12 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "var")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_var, status=done
-        value <- private$.validate_obsvar_dataframe(value, "var")
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "var",
-          private$.compression
-        )
+        private$.validate_obsvar_dataframe(value, "var") |>
+          write_h5ad_element(
+            private$.h5obj,
+            "var",
+            private$.compression
+          )
       }
     },
     #' @field obs_names See [AnnData-usage]
@@ -249,13 +240,12 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "uns")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_uns, status=done
-        value <- private$.validate_named_list(value, "uns")
-        write_h5ad_element(
-          value,
-          private$.h5obj,
-          "uns",
-          private$.compression
-        )
+        private$.validate_named_list(value, "uns") |>
+          write_h5ad_element(
+            private$.h5obj,
+            "uns",
+            private$.compression
+          )
       }
     }
   ),

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -94,6 +94,7 @@ HDF5AnnData <- R6::R6Class(
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_obsm, status=done
         private$.validate_aligned_mapping(
+          value,
           "obsm",
           c(self$n_obs()),
           expected_rownames = self$obs_names
@@ -147,7 +148,7 @@ HDF5AnnData <- R6::R6Class(
             private$.h5obj,
             "obsp",
             private$.compression
-        )
+          )
       }
     },
     #' @field varp See [AnnData-usage]

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -44,7 +44,8 @@ HDF5AnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_X, status=done
-        read_h5ad_element(private$.h5obj, "X")
+        read_h5ad_element(private$.h5obj, "X") |>
+          private$.add_matrix_dimnames("X")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_X, status=done
         private$.validate_aligned_array(
@@ -67,7 +68,8 @@ HDF5AnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_layers, status=done
-        read_h5ad_element(private$.h5obj, "layers")
+        read_h5ad_element(private$.h5obj, "layers") |>
+          private$.add_mapping_dimnames("layers")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_layers, status=done
         private$.validate_aligned_mapping(
@@ -90,14 +92,17 @@ HDF5AnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_obsm, status=done
-        read_h5ad_element(private$.h5obj, "obsm")
+        read_h5ad_element(private$.h5obj, "obsm") |>
+          private$.add_mapping_dimnames("obsm")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_obsm, status=done
         private$.validate_aligned_mapping(
           value,
           "obsm",
           c(self$n_obs()),
-          expected_rownames = self$obs_names
+          expected_rownames = self$obs_names,
+          strip_rownames = TRUE,
+          strip_colnames = FALSE
         ) |>
           write_h5ad_element(
             private$.h5obj,
@@ -112,14 +117,17 @@ HDF5AnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_varm, status=done
-        read_h5ad_element(private$.h5obj, "varm")
+        read_h5ad_element(private$.h5obj, "varm") |>
+          private$.add_mapping_dimnames("varm")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_varm, status=done
         private$.validate_aligned_mapping(
           value,
           "varm",
           c(self$n_vars()),
-          expected_rownames = self$var_names
+          expected_rownames = self$var_names,
+          strip_rownames = TRUE,
+          strip_colnames = FALSE
         ) |>
           write_h5ad_element(
             private$.h5obj,
@@ -134,7 +142,8 @@ HDF5AnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_obsp, status=done
-        read_h5ad_element(private$.h5obj, "obsp")
+        read_h5ad_element(private$.h5obj, "obsp") |>
+          private$.add_mapping_dimnames("obsp")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_obsp, status=done
         private$.validate_aligned_mapping(
@@ -157,7 +166,8 @@ HDF5AnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=HDF5AnnData, feature=get_varp, status=done
-        read_h5ad_element(private$.h5obj, "varp")
+        read_h5ad_element(private$.h5obj, "varp") |>
+          private$.add_mapping_dimnames("varp")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_varp, status=done
         private$.validate_aligned_mapping(

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -104,7 +104,8 @@ HDF5AnnData <- R6::R6Class(
         write_h5ad_element(
           value,
           private$.h5obj,
-          "obsm"
+          "obsm",
+          private$.compression
         )
       }
     },
@@ -126,7 +127,8 @@ HDF5AnnData <- R6::R6Class(
         write_h5ad_element(
           value,
           private$.h5obj,
-          "varm"
+          "varm",
+          private$.compression
         )
       }
     },
@@ -149,7 +151,8 @@ HDF5AnnData <- R6::R6Class(
         write_h5ad_element(
           value,
           private$.h5obj,
-          "obsp"
+          "obsp",
+          private$.compression
         )
       }
     },
@@ -172,7 +175,8 @@ HDF5AnnData <- R6::R6Class(
         write_h5ad_element(
           value,
           private$.h5obj,
-          "varp"
+          "varp",
+          private$.compression
         )
       }
     },
@@ -207,7 +211,8 @@ HDF5AnnData <- R6::R6Class(
         write_h5ad_element(
           value,
           private$.h5obj,
-          "var"
+          "var",
+          private$.compression
         )
       }
     },
@@ -245,7 +250,12 @@ HDF5AnnData <- R6::R6Class(
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_uns, status=done
         value <- private$.validate_named_list(value, "uns")
-        write_h5ad_element(value, private$.h5obj, "uns")
+        write_h5ad_element(
+          value,
+          private$.h5obj,
+          "uns",
+          private$.compression
+        )
       }
     }
   ),

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -51,8 +51,8 @@ HDF5AnnData <- R6::R6Class(
           value,
           "X",
           shape = c(self$n_obs(), self$n_vars()),
-          expected_rownames = rownames(self),
-          expected_colnames = colnames(self)
+          expected_rownames = self$obs_names,
+          expected_colnames = self$var_names
         )
         write_h5ad_element(
           value,
@@ -75,8 +75,8 @@ HDF5AnnData <- R6::R6Class(
           value,
           "layers",
           c(self$n_obs(), self$n_vars()),
-          expected_rownames = rownames(self),
-          expected_colnames = colnames(self)
+          expected_rownames = self$obs_names,
+          expected_colnames = self$var_names
         )
         write_h5ad_element(
           value,
@@ -99,7 +99,7 @@ HDF5AnnData <- R6::R6Class(
           value,
           "obsm",
           c(self$n_obs()),
-          expected_rownames = rownames(self)
+          expected_rownames = self$obs_names
         )
         write_h5ad_element(
           value,
@@ -121,7 +121,7 @@ HDF5AnnData <- R6::R6Class(
           value,
           "varm",
           c(self$n_vars()),
-          expected_rownames = colnames(self)
+          expected_rownames = self$var_names
         )
         write_h5ad_element(
           value,
@@ -143,8 +143,8 @@ HDF5AnnData <- R6::R6Class(
           value,
           "obsp",
           c(self$n_obs(), self$n_obs()),
-          expected_rownames = rownames(self),
-          expected_colnames = rownames(self)
+          expected_rownames = self$obs_names,
+          expected_colnames = self$obs_names
         )
         write_h5ad_element(
           value,
@@ -166,8 +166,8 @@ HDF5AnnData <- R6::R6Class(
           value,
           "varp",
           c(self$n_vars(), self$n_vars()),
-          expected_rownames = colnames(self),
-          expected_colnames = colnames(self)
+          expected_rownames = self$var_names,
+          expected_colnames = self$var_names
         )
         write_h5ad_element(
           value,

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -39,6 +39,8 @@ InMemoryAnnData <- R6::R6Class(
     .layers = NULL,
     .obs = NULL,
     .var = NULL,
+    .obs_names = NULL,
+    .var_names = NULL,
     .obsm = NULL,
     .varm = NULL,
     .obsp = NULL,
@@ -50,15 +52,16 @@ InMemoryAnnData <- R6::R6Class(
     X = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_X, status=done
-        private$.X
+        private$.X |>
+          private$.add_matrix_dimnames("X")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_X, status=done
         private$.X <- private$.validate_aligned_array(
           value,
           "X",
           shape = c(self$n_obs(), self$n_vars()),
-          expected_rownames = self$obs_names,
-          expected_colnames = self$var_names
+          expected_rownames = private$.obs_names,
+          expected_colnames = private$.var_names
         )
         self
       }
@@ -67,15 +70,16 @@ InMemoryAnnData <- R6::R6Class(
     layers = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_layers, status=done
-        private$.layers
+        private$.layers |>
+          private$.add_mapping_dimnames("layers")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_layers, status=done
         private$.layers <- private$.validate_aligned_mapping(
           value,
           "layers",
           c(self$n_obs(), self$n_vars()),
-          expected_rownames = self$obs_names,
-          expected_colnames = self$var_names
+          expected_rownames = private$.obs_names,
+          expected_colnames = private$.var_names
         )
         self
       }
@@ -84,9 +88,15 @@ InMemoryAnnData <- R6::R6Class(
     obs = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_obs, status=done
-        private$.obs
+        private$.obs |>
+          private$.add_obsvar_dimnames("obs")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_obs, status=done
+        # Extract obs_names if present before validation
+        if (!is.null(value) && has_row_names(value)) {
+          private$.obs_names <- rownames(value)
+          rownames(value) <- NULL
+        }
         private$.obs <- private$.validate_obsvar_dataframe(value, "obs")
         self
       }
@@ -95,9 +105,15 @@ InMemoryAnnData <- R6::R6Class(
     var = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_var, status=done
-        private$.var
+        private$.var |>
+          private$.add_obsvar_dimnames("var")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_var, status=done
+        # Extract var_names if present before validation
+        if (!is.null(value) && has_row_names(value)) {
+          private$.var_names <- rownames(value)
+          rownames(value) <- NULL
+        }
         private$.var <- private$.validate_obsvar_dataframe(value, "var")
         self
       }
@@ -106,10 +122,10 @@ InMemoryAnnData <- R6::R6Class(
     obs_names = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_obs_names, status=done
-        rownames(private$.obs)
+        private$.obs_names
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_obs_names, status=done
-        rownames(private$.obs) <- private$.validate_obsvar_names(value, "obs")
+        private$.obs_names <- private$.validate_obsvar_names(value, "obs")
         self
       }
     },
@@ -117,10 +133,10 @@ InMemoryAnnData <- R6::R6Class(
     var_names = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_var_names, status=done
-        rownames(private$.var)
+        private$.var_names
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_var_names, status=done
-        rownames(private$.var) <- private$.validate_obsvar_names(value, "var")
+        private$.var_names <- private$.validate_obsvar_names(value, "var")
         self
       }
     },
@@ -128,14 +144,17 @@ InMemoryAnnData <- R6::R6Class(
     obsm = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_obsm, status=done
-        private$.obsm
+        private$.obsm |>
+          private$.add_mapping_dimnames("obsm")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_obsm, status=done
         private$.obsm <- private$.validate_aligned_mapping(
           value,
           "obsm",
           c(self$n_obs()),
-          expected_rownames = self$obs_names
+          expected_rownames = private$.obs_names,
+          strip_rownames = TRUE,
+          strip_colnames = FALSE
         )
         self
       }
@@ -144,14 +163,17 @@ InMemoryAnnData <- R6::R6Class(
     varm = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_varm, status=done
-        private$.varm
+        private$.varm |>
+          private$.add_mapping_dimnames("varm")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_varm, status=done
         private$.varm <- private$.validate_aligned_mapping(
           value,
           "varm",
           c(self$n_vars()),
-          expected_rownames = self$var_names
+          expected_rownames = private$.var_names,
+          strip_rownames = TRUE,
+          strip_colnames = FALSE
         )
         self
       }
@@ -160,15 +182,16 @@ InMemoryAnnData <- R6::R6Class(
     obsp = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_obsp, status=done
-        private$.obsp
+        private$.obsp |>
+          private$.add_mapping_dimnames("obsp")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_obsp, status=done
         private$.obsp <- private$.validate_aligned_mapping(
           value,
           "obsp",
           c(self$n_obs(), self$n_obs()),
-          expected_rownames = self$obs_names,
-          expected_colnames = self$obs_names
+          expected_rownames = private$.obs_names,
+          expected_colnames = private$.obs_names
         )
         self
       }
@@ -177,15 +200,16 @@ InMemoryAnnData <- R6::R6Class(
     varp = function(value) {
       if (missing(value)) {
         # trackstatus: class=InMemoryAnnData, feature=get_varp, status=done
-        private$.varp
+        private$.varp |>
+          private$.add_mapping_dimnames("varp")
       } else {
         # trackstatus: class=InMemoryAnnData, feature=set_varp, status=done
         private$.varp <- private$.validate_aligned_mapping(
           value,
           "varp",
           c(self$n_vars(), self$n_vars()),
-          expected_rownames = self$var_names,
-          expected_colnames = self$var_names
+          expected_rownames = private$.var_names,
+          expected_colnames = private$.var_names
         )
         self
       }
@@ -241,6 +265,14 @@ InMemoryAnnData <- R6::R6Class(
       if (!is.data.frame(var)) {
         cli_abort("{.arg var} must be a {.cls data.frame}")
       }
+
+      # Extract and store obs_names/var_names separately
+      private$.obs_names <- rownames(obs)
+      private$.var_names <- rownames(var)
+
+      # Remove rownames from the data.frames before storing
+      rownames(obs) <- NULL
+      rownames(var) <- NULL
       private$.obs <- obs
       private$.var <- var
 

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -60,8 +60,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "X",
           shape = c(self$n_obs(), self$n_vars()),
-          expected_rownames = private$.obs_names,
-          expected_colnames = private$.var_names
+          expected_rownames = self$obs_names,
+          expected_colnames = self$var_names
         )
         self
       }
@@ -78,8 +78,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "layers",
           c(self$n_obs(), self$n_vars()),
-          expected_rownames = private$.obs_names,
-          expected_colnames = private$.var_names
+          expected_rownames = self$obs_names,
+          expected_colnames = self$var_names
         )
         self
       }
@@ -152,7 +152,7 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "obsm",
           c(self$n_obs()),
-          expected_rownames = private$.obs_names,
+          expected_rownames = self$obs_names,
           strip_rownames = TRUE,
           strip_colnames = FALSE
         )
@@ -171,7 +171,7 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "varm",
           c(self$n_vars()),
-          expected_rownames = private$.var_names,
+          expected_rownames = self$var_names,
           strip_rownames = TRUE,
           strip_colnames = FALSE
         )
@@ -190,8 +190,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "obsp",
           c(self$n_obs(), self$n_obs()),
-          expected_rownames = private$.obs_names,
-          expected_colnames = private$.obs_names
+          expected_rownames = self$obs_names,
+          expected_colnames = self$obs_names
         )
         self
       }
@@ -208,8 +208,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "varp",
           c(self$n_vars(), self$n_vars()),
-          expected_rownames = private$.var_names,
-          expected_colnames = private$.var_names
+          expected_rownames = self$var_names,
+          expected_colnames = self$var_names
         )
         self
       }

--- a/R/InMemoryAnnData.R
+++ b/R/InMemoryAnnData.R
@@ -57,8 +57,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "X",
           shape = c(self$n_obs(), self$n_vars()),
-          expected_rownames = rownames(self),
-          expected_colnames = colnames(self)
+          expected_rownames = self$obs_names,
+          expected_colnames = self$var_names
         )
         self
       }
@@ -74,8 +74,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "layers",
           c(self$n_obs(), self$n_vars()),
-          expected_rownames = rownames(self),
-          expected_colnames = colnames(self)
+          expected_rownames = self$obs_names,
+          expected_colnames = self$var_names
         )
         self
       }
@@ -135,7 +135,7 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "obsm",
           c(self$n_obs()),
-          expected_rownames = rownames(self)
+          expected_rownames = self$obs_names
         )
         self
       }
@@ -151,7 +151,7 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "varm",
           c(self$n_vars()),
-          expected_rownames = colnames(self)
+          expected_rownames = self$var_names
         )
         self
       }
@@ -167,8 +167,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "obsp",
           c(self$n_obs(), self$n_obs()),
-          expected_rownames = rownames(self),
-          expected_colnames = rownames(self)
+          expected_rownames = self$obs_names,
+          expected_colnames = self$obs_names
         )
         self
       }
@@ -184,8 +184,8 @@ InMemoryAnnData <- R6::R6Class(
           value,
           "varp",
           c(self$n_vars(), self$n_vars()),
-          expected_rownames = colnames(self),
-          expected_colnames = colnames(self)
+          expected_rownames = self$var_names,
+          expected_colnames = self$var_names
         )
         self
       }

--- a/R/from_Seurat.R
+++ b/R/from_Seurat.R
@@ -297,7 +297,23 @@ from_Seurat <- function(
         "i" = "Available reductions: {.val {SeuratObject::Reductions(seurat_obj)}}"
       ))
     }
-    SeuratObject::Loadings(seurat_obj, .reduction)
+    mat <- SeuratObject::Loadings(seurat_obj, .reduction)
+
+    # NOTE: loadings only contains a subset of the rows that should be in the varm.
+    # hence, expand it to all of the varnames in the adata
+    if (!identical(rownames(mat), adata$var_names)) {
+      cli_warn(c(
+        "Row names of a varm matrix coming from Seurat do not match the var names",
+        "Hence we need to expand the matrix to include all var names."
+      ))
+
+      expanded_mat <- matrix(0, nrow = nrow(adata$var), ncol = ncol(mat))
+      rownames(expanded_mat) <- adata$var_names
+      colnames(expanded_mat) <- colnames(mat)
+      expanded_mat[rownames(mat), ] <- mat
+
+      mat <- expanded_mat
+    }
   })
 }
 

--- a/R/from_Seurat.R
+++ b/R/from_Seurat.R
@@ -303,7 +303,7 @@ from_Seurat <- function(
     # hence, expand it to all of the varnames in the adata
     if (!identical(rownames(mat), adata$var_names)) {
       cli_warn(c(
-        "Row names of {.code Loadings(seurat_obj, {.val {.reduction})} do not match the expected var names",
+        "Row names of {.code Loadings(seurat_obj, {.val {(.reduction)}})} do not match the expected var names",
         "!" = "The matrix will be expanded to include all var names."
       ))
 

--- a/R/from_Seurat.R
+++ b/R/from_Seurat.R
@@ -303,8 +303,8 @@ from_Seurat <- function(
     # hence, expand it to all of the varnames in the adata
     if (!identical(rownames(mat), adata$var_names)) {
       cli_warn(c(
-        "Row names of a varm matrix coming from Seurat do not match the var names",
-        "Hence we need to expand the matrix to include all var names."
+        "Row names of {.code Loadings(seurat_obj, {.val {.reduction})} do not match the expected var names",
+        "!" = "The matrix will be expanded to include all var names."
       ))
 
       expanded_mat <- matrix(0, nrow = nrow(adata$var), ncol = ncol(mat))

--- a/R/from_Seurat.R
+++ b/R/from_Seurat.R
@@ -269,7 +269,7 @@ from_Seurat <- function(
   adata$obsm <- purrr::map(obsm_mapping, function(.reduction) {
     if (!(.reduction %in% SeuratObject::Reductions(seurat_obj))) {
       cli_abort(c(
-        "Reduction {.val {.reduction}} not found in Seurat object.",
+        "Reduction {.val {(.reduction)}} not found in Seurat object.",
         "i" = "Available reductions: {.val {SeuratObject::Reductions(seurat_obj)}}"
       ))
     }
@@ -293,7 +293,7 @@ from_Seurat <- function(
   adata$varm <- purrr::map(varm_mapping, function(.reduction) {
     if (!(.reduction %in% SeuratObject::Reductions(seurat_obj))) {
       cli_abort(c(
-        "Reduction {.val {.reduction}} not found in Seurat object.",
+        "Reduction {.val {(.reduction)}} not found in Seurat object.",
         "i" = "Available reductions: {.val {SeuratObject::Reductions(seurat_obj)}}"
       ))
     }
@@ -358,7 +358,7 @@ from_Seurat <- function(
     # Check if the misc data exists
     if (!(.varp %in% names(SeuratObject::Misc(seurat_obj)))) {
       cli_abort(c(
-        "Misc data {.val {.varp}} not found in Seurat object.",
+        "Misc data {.val {(.varp)}} not found in Seurat object.",
         "i" = "Available misc data: {.val {names(SeuratObject::Misc(seurat_obj))}}"
       ))
     }
@@ -382,7 +382,7 @@ from_Seurat <- function(
   adata$uns <- purrr::map(uns_mapping, function(.misc) {
     if (!(.misc %in% names(SeuratObject::Misc(seurat_obj)))) {
       cli_abort(c(
-        "Misc data {.val {.misc}} not found in Seurat object.",
+        "Misc data {.val {(.misc)}} not found in Seurat object.",
         "i" = "Available misc data: {.val {names(SeuratObject::Misc(seurat_obj))}}"
       ))
     }

--- a/R/generate_dataset.R
+++ b/R/generate_dataset.R
@@ -312,6 +312,7 @@ generate_dataset <- function(
     if (obsm_type %in% names(vector_generators)) {
       generate_dataframe(n_obs, obsm_type)
     } else {
+      # generate n_obs vars to stay aligned with dummy-anndata, see scverse/anndataR#286
       generate_matrix(n_obs, n_vars = n_obs, obsm_type)
     }
   })
@@ -322,6 +323,7 @@ generate_dataset <- function(
     if (varm_type %in% names(vector_generators)) {
       generate_dataframe(n_vars, varm_type)
     } else {
+      # generate n_vars vars to stay aligned with dummy-anndata, see scverse/anndataR#286
       generate_matrix(n_vars, n_vars = n_vars, varm_type)
     }
   })

--- a/tests/testthat/test-HDF5AnnData.R
+++ b/tests/testthat/test-HDF5AnnData.R
@@ -217,7 +217,10 @@ test_that("writing obsm works", {
 
   obsm_x <- matrix(rnorm(10 * 5), nrow = 10, ncol = 5)
   h5ad$obsm <- list(X = obsm_x)
-  expect_identical(h5ad$obsm$X, obsm_x)
+  # obsm should now have rownames added on-the-fly
+  expected_obsm_x <- obsm_x
+  rownames(expected_obsm_x) <- h5ad$obs_names
+  expect_identical(h5ad$obsm$X, expected_obsm_x)
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_varm, status=done
@@ -228,7 +231,10 @@ test_that("writing varm works", {
   h5ad <- HDF5AnnData$new(h5ad_file, obs = obs, var = var)
   varm_x <- matrix(rnorm(20 * 5), nrow = 20, ncol = 5)
   h5ad$varm <- list(PCs = varm_x)
-  expect_identical(h5ad$varm$PCs, varm_x)
+  # varm should now have rownames added on-the-fly
+  expected_varm_x <- varm_x
+  rownames(expected_varm_x) <- h5ad$var_names
+  expect_identical(h5ad$varm$PCs, expected_varm_x)
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_obsp, status=done
@@ -240,7 +246,10 @@ test_that("writing obsp works", {
 
   obsp_x <- matrix(rnorm(10 * 10), nrow = 10, ncol = 10)
   h5ad$obsp <- list(connectivities = obsp_x)
-  expect_identical(h5ad$obsp$connectivities, obsp_x)
+  # obsp should now have dimnames added on-the-fly
+  expected_obsp_x <- obsp_x
+  dimnames(expected_obsp_x) <- list(h5ad$obs_names, h5ad$obs_names)
+  expect_identical(h5ad$obsp$connectivities, expected_obsp_x)
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_varp, status=done
@@ -252,7 +261,10 @@ test_that("writing varp works", {
 
   varp_x <- matrix(rnorm(20 * 20), nrow = 20, ncol = 20)
   h5ad$varp <- list(connectivities = varp_x)
-  expect_identical(h5ad$varp$connectivities, varp_x)
+  # varp should now have dimnames added on-the-fly
+  expected_varp_x <- varp_x
+  dimnames(expected_varp_x) <- list(h5ad$var_names, h5ad$var_names)
+  expect_identical(h5ad$varp$connectivities, expected_varp_x)
 })
 
 # trackstatus: class=HDF5AnnData, feature=test_set_uns, status=done

--- a/tests/testthat/test-InMemoryAnnData.R
+++ b/tests/testthat/test-InMemoryAnnData.R
@@ -10,9 +10,9 @@ test_that("Creating InMemoryAnnData works", {
 
   # trackstatus: class=InMemoryAnnData, feature=test_get_X, status=done
   # X should now have dimnames added on-the-fly
-  expected_X <- dummy$X
-  dimnames(expected_X) <- list(rownames(dummy$obs), rownames(dummy$var))
-  expect_equal(ad$X, expected_X)
+  expected_x <- dummy$X
+  dimnames(expected_x) <- list(rownames(dummy$obs), rownames(dummy$var))
+  expect_equal(ad$X, expected_x)
   # trackstatus: class=InMemoryAnnData, feature=test_get_obs, status=done
   expect_equal(ad$obs, dummy$obs)
   # trackstatus: class=InMemoryAnnData, feature=test_get_var, status=done
@@ -128,9 +128,9 @@ test_that("write to X", {
   ad$X <- X2
 
   # X should have dimnames added on-the-fly
-  expected_X2 <- X2
-  dimnames(expected_X2) <- list(ad$obs_names, ad$var_names)
-  expect_equal(ad$X, expected_X2)
+  expected_x2 <- X2
+  dimnames(expected_x2) <- list(ad$obs_names, ad$var_names)
+  expect_equal(ad$X, expected_x2)
 
   # change row in X
   ad$X[2, ] <- 10
@@ -256,14 +256,14 @@ test_that("write to layers", {
 
   ## element assignment
   ad$layers[["X2"]] <- dummy$X + 2
-  expected_X2 <- dummy$X + 2
-  dimnames(expected_X2) <- list(ad$obs_names, ad$var_names)
-  expect_equal(ad$layers[["X2"]], expected_X2)
+  expected_x2 <- dummy$X + 2
+  dimnames(expected_x2) <- list(ad$obs_names, ad$var_names)
+  expect_equal(ad$layers[["X2"]], expected_x2)
 
   ad$layers[["X4"]] <- dummy$X + 4
-  expected_X4 <- dummy$X + 4
-  dimnames(expected_X4) <- list(ad$obs_names, ad$var_names)
-  expect_equal(ad$layers[["X4"]], expected_X4)
+  expected_x4 <- dummy$X + 4
+  dimnames(expected_x4) <- list(ad$obs_names, ad$var_names)
+  expect_equal(ad$layers[["X4"]], expected_x4)
 
   ## list assignment
   ad$layers <- rev(dummy$layers)

--- a/tests/testthat/test-InMemoryAnnData.R
+++ b/tests/testthat/test-InMemoryAnnData.R
@@ -9,7 +9,10 @@ test_that("Creating InMemoryAnnData works", {
   )
 
   # trackstatus: class=InMemoryAnnData, feature=test_get_X, status=done
-  expect_equal(ad$X, dummy$X)
+  # X should now have dimnames added on-the-fly
+  expected_X <- dummy$X
+  dimnames(expected_X) <- list(rownames(dummy$obs), rownames(dummy$var))
+  expect_equal(ad$X, expected_X)
   # trackstatus: class=InMemoryAnnData, feature=test_get_obs, status=done
   expect_equal(ad$obs, dummy$obs)
   # trackstatus: class=InMemoryAnnData, feature=test_get_var, status=done
@@ -56,7 +59,16 @@ test_that("'layers' works", {
     expect_no_condition({
       ad <- AnnData(obs = obs, var = var, layers = layers)
     })
-    expect_identical(ad$layers, layers)
+    # Expected layers should have dimnames added
+    expected_layers <- layers
+    if (!is.null(expected_layers)) {
+      for (i in seq_along(expected_layers)) {
+        if (!is.null(expected_layers[[i]])) {
+          dimnames(expected_layers[[i]]) <- list(rownames(obs), rownames(var))
+        }
+      }
+    }
+    expect_identical(ad$layers, expected_layers)
   }
 
   obs <- var <- data.frame()
@@ -115,15 +127,22 @@ test_that("write to X", {
   X2 <- Matrix::rsparsematrix(nrow = 10, ncol = 20, density = .1)
   ad$X <- X2
 
-  expect_equal(ad$X, X2)
+  # X should have dimnames added on-the-fly
+  expected_X2 <- X2
+  dimnames(expected_X2) <- list(ad$obs_names, ad$var_names)
+  expect_equal(ad$X, expected_X2)
 
   # change row in X
   ad$X[2, ] <- 10
-  expect_equal(ad$X[2, ], rep(10, 20L))
+  expected_row <- rep(10, 20L)
+  names(expected_row) <- ad$var_names
+  expect_equal(ad$X[2, ], expected_row)
 
   # change column in X
   ad$X[, 3] <- 5
-  expect_equal(ad$X[, 3], rep(5, 10L))
+  expected_col <- rep(5, 10L)
+  names(expected_col) <- ad$obs_names
+  expect_equal(ad$X[, 3], expected_col)
 })
 
 # trackstatus: class=InMemoryAnnData, feature=test_set_obs, status=done
@@ -143,7 +162,10 @@ test_that("write to obs", {
 
   expect_equal(ncol(ad$obs), 3)
   expect_equal(nrow(ad$obs), 10)
-  expect_equal(ad$obs, obs2)
+  # obs should now have rownames added on-the-fly
+  expected_obs2 <- obs2
+  rownames(expected_obs2) <- ad$obs_names
+  expect_equal(ad$obs, expected_obs2)
 
   # change row in obs
   obs2row <- data.frame(foo = "a", bar = 3, zing = FALSE)
@@ -172,7 +194,10 @@ test_that("write to var", {
 
   expect_equal(ncol(ad$var), 3)
   expect_equal(nrow(ad$var), 20)
-  expect_equal(ad$var, var2)
+  # var should now have rownames added on-the-fly
+  expected_var2 <- var2
+  rownames(expected_var2) <- ad$var_names
+  expect_equal(ad$var, expected_var2)
 
   # change row in var
   var2row <- data.frame(foo = "a", bar = 3, zing = FALSE)
@@ -231,19 +256,35 @@ test_that("write to layers", {
 
   ## element assignment
   ad$layers[["X2"]] <- dummy$X + 2
-  expect_equal(ad$layers[["X2"]], dummy$X + 2)
+  expected_X2 <- dummy$X + 2
+  dimnames(expected_X2) <- list(ad$obs_names, ad$var_names)
+  expect_equal(ad$layers[["X2"]], expected_X2)
 
   ad$layers[["X4"]] <- dummy$X + 4
-  expect_equal(ad$layers[["X4"]], dummy$X + 4)
+  expected_X4 <- dummy$X + 4
+  dimnames(expected_X4) <- list(ad$obs_names, ad$var_names)
+  expect_equal(ad$layers[["X4"]], expected_X4)
 
   ## list assignment
   ad$layers <- rev(dummy$layers)
-  expect_equal(ad$layers, rev(dummy$layers))
+  expected_layers <- rev(dummy$layers)
+  for (i in seq_along(expected_layers)) {
+    if (!is.null(expected_layers[[i]])) {
+      dimnames(expected_layers[[i]]) <- list(ad$obs_names, ad$var_names)
+    }
+  }
+  expect_equal(ad$layers, expected_layers)
 
   ## remove
   ad$layers <- NULL
   expect_true(is.null(ad$layers))
   ## add to NULL
   ad$layers <- dummy$layers
-  expect_identical(ad$layers, dummy$layers)
+  expected_layers <- dummy$layers
+  for (i in seq_along(expected_layers)) {
+    if (!is.null(expected_layers[[i]])) {
+      dimnames(expected_layers[[i]]) <- list(ad$obs_names, ad$var_names)
+    }
+  }
+  expect_identical(ad$layers, expected_layers)
 })

--- a/tests/testthat/test-as_SingleCellExperiment.R
+++ b/tests/testthat/test-as_SingleCellExperiment.R
@@ -137,6 +137,9 @@ for (obsp_key in names(ad$obsp)) {
     sce_matrix <- as.matrix(colPair(sce, obsp_key, asSparse = TRUE))
     ad_matrix <- as.matrix(ad$obsp[[obsp_key]])
 
+    # Remove dimnames for comparison since SCE doesn't preserve AnnData dimnames
+    dimnames(sce_matrix) <- NULL
+    dimnames(ad_matrix) <- NULL
     expect_equal(sce_matrix, ad_matrix, info = paste0("obsp_key: ", obsp_key))
   })
 }
@@ -158,6 +161,9 @@ for (varp_key in names(ad$varp)) {
     sce_matrix <- as.matrix(rowPair(sce, varp_key, asSparse = TRUE))
     ad_matrix <- as.matrix(ad$varp[[varp_key]])
 
+    # Remove dimnames for comparison since SCE doesn't preserve AnnData dimnames
+    dimnames(sce_matrix) <- NULL
+    dimnames(ad_matrix) <- NULL
     expect_equal(sce_matrix, ad_matrix, info = paste0("varp_key: ", varp_key))
   })
 }

--- a/tests/testthat/test-from_Seurat.R
+++ b/tests/testthat/test-from_Seurat.R
@@ -118,7 +118,7 @@ test_that("as_AnnData (Seurat) retains pca", {
   )
   skip_if(!is.null(msg), message = msg)
 
-  # trackstatus: class=Seurat, feature=test_set_obsm, status=done
+  # trackstatus: class=Seurat, feature=test_set_obsm, status=wip
   expect_equal(
     ad$obsm[["pca"]],
     Embeddings(obj, reduction = "pca"),

--- a/tests/testthat/test-from_Seurat.R
+++ b/tests/testthat/test-from_Seurat.R
@@ -117,17 +117,26 @@ test_that("as_AnnData (Seurat) retains pca", {
   )
   skip_if(!is.null(msg), message = msg)
 
-  # trackstatus: class=Seurat, feature=test_set_obsm, status=wip
+  # trackstatus: class=Seurat, feature=test_set_obsm, status=done
   expect_equal(
     ad$obsm[["pca"]],
     Embeddings(obj, reduction = "pca"),
     ignore_attr = TRUE
   )
 
-  # trackstatus: class=Seurat, feature=test_set_varm, status=wip
+  # trackstatus: class=Seurat, feature=test_set_varm, status=done
+  expanded_varm_pca <- ad$varm[["pca"]]
+  loadings <- Loadings(obj, reduction = "pca")
+
+  # check whether rows not in loadings are all zero
+  should_be_zero <- expanded_varm_pca[!rownames(expanded_varm_pca) %in% rownames(loadings), , drop = FALSE]
+  expect_true(all(should_be_zero == 0))
+
+  # now check the matching rows
+  matching_varm_pca <- expanded_varm_pca[rownames(loadings), , drop = FALSE]
   expect_equal(
-    ad$varm[["pca"]],
-    Loadings(obj, reduction = "pca"),
+    matching_varm_pca,
+    loadings,
     ignore_attr = TRUE
   )
 })

--- a/tests/testthat/test-from_Seurat.R
+++ b/tests/testthat/test-from_Seurat.R
@@ -12,7 +12,10 @@ obj <- FindVariableFeatures(obj, verbose = FALSE)
 obj <- ScaleData(obj, verbose = FALSE)
 obj <- RunPCA(obj, npcs = 10L, verbose = FALSE)
 obj <- FindNeighbors(obj, verbose = FALSE)
-obj <- RunUMAP(obj, dims = 1:10, verbose = FALSE)
+# Suppress Seurat UWOT warning
+withr::with_options(list("Seurat.warn.umap.uwot" = FALSE), {
+  obj <- RunUMAP(obj, dims = 1:10, verbose = FALSE)
+})
 
 active_assay <- obj[[DefaultAssay(obj)]]
 

--- a/tests/testthat/test-from_Seurat.R
+++ b/tests/testthat/test-from_Seurat.R
@@ -196,7 +196,7 @@ test_that("as_AnnData (Seurat) works with v3 Assays", {
 
   expect_warning(
     adata_v3_assay <- as_AnnData(obj_v3_assay),
-    regexp = "Row names of a varm matrix coming from Seurat do not match the var names"
+    regexp = "Row names of .* do not match the expected var names"
   )
 
   expect_identical(
@@ -228,7 +228,7 @@ test_that("as_AnnData (Seurat) works with list mappings", {
           FALSE
         }
       ),
-      regexp = "Row names of a varm matrix coming from Seurat do not match the var names"
+      regexp = "Row names of .* do not match the expected var names"
     )
   )
 })
@@ -248,7 +248,7 @@ test_that("as_AnnData (Seurat) works with unnamed mappings", {
         varp_mapping = unname(.from_Seurat_guess_varps(obj)) %||% FALSE,
         uns_mapping = unname(.from_Seurat_guess_uns(obj)) %||% FALSE
       ),
-      regexp = "Row names of a varm matrix coming from Seurat do not match the var names"
+      regexp = "Row names of .* do not match the expected var names"
     )
   )
 })

--- a/tests/testthat/test-from_Seurat.R
+++ b/tests/testthat/test-from_Seurat.R
@@ -130,7 +130,11 @@ test_that("as_AnnData (Seurat) retains pca", {
   loadings <- Loadings(obj, reduction = "pca")
 
   # check whether rows not in loadings are all zero
-  should_be_zero <- expanded_varm_pca[!rownames(expanded_varm_pca) %in% rownames(loadings), , drop = FALSE]
+  should_be_zero <- expanded_varm_pca[
+    !rownames(expanded_varm_pca) %in% rownames(loadings),
+    ,
+    drop = FALSE
+  ]
   expect_true(all(should_be_zero == 0))
 
   # now check the matching rows
@@ -250,6 +254,12 @@ test_that("as_AnnData (Seurat) works with unnamed mappings", {
 })
 
 test_that("as_AnnData (Seurat) works with empty mappings", {
-  expect_warning(as_AnnData(obj, varm_mapping = NULL), regexp = "argument is empty")
-  expect_warning(as_AnnData(obj, varm_mapping = c()), regexp = "argument is empty")
+  expect_warning(
+    as_AnnData(obj, varm_mapping = NULL),
+    regexp = "argument is empty"
+  )
+  expect_warning(
+    as_AnnData(obj, varm_mapping = c()),
+    regexp = "argument is empty"
+  )
 })

--- a/tests/testthat/test-from_Seurat.R
+++ b/tests/testthat/test-from_Seurat.R
@@ -16,7 +16,8 @@ obj <- RunUMAP(obj, dims = 1:10, verbose = FALSE)
 
 active_assay <- obj[[DefaultAssay(obj)]]
 
-ad <- as_AnnData(obj)
+# converting to anndata produces warning due to hvg subsetting
+ad <- suppressWarnings(as_AnnData(obj))
 
 test_that("as_AnnData (Seurat) retains number of observations and features", {
   expect_equal(ad$n_obs(), 200L)
@@ -189,7 +190,10 @@ test_that("as_AnnData (Seurat) works with v3 Assays", {
     obj_v3_assay[["RNA"]] <- as(Seurat::GetAssay(obj, "RNA"), "Assay")
   )
 
-  adata_v3_assay <- as_AnnData(obj_v3_assay)
+  expect_warning(
+    adata_v3_assay <- as_AnnData(obj_v3_assay),
+    regexp = "Row names of a varm matrix coming from Seurat do not match the var names"
+  )
 
   expect_identical(
     to_R_matrix(adata_v3_assay$layers$counts),
@@ -200,24 +204,27 @@ test_that("as_AnnData (Seurat) works with v3 Assays", {
 test_that("as_AnnData (Seurat) works with list mappings", {
   active_assay <- SeuratObject::DefaultAssay(obj)
   expect_no_error(
-    as_AnnData(
-      obj,
-      layers_mapping = as.list(.from_Seurat_guess_layers(obj, active_assay)),
-      obs_mapping = as.list(.from_Seurat_guess_obs(obj, active_assay)),
-      var_mapping = as.list(.from_Seurat_guess_var(obj, active_assay)),
-      obsm_mapping = as.list(.from_Seurat_guess_obsms(obj, active_assay)),
-      varm_mapping = as.list(.from_Seurat_guess_varms(obj, active_assay)),
-      obsp_mapping = as.list(.from_Seurat_guess_obsps(obj, active_assay)),
-      varp_mapping = if (length(as.list(.from_Seurat_guess_varps(obj))) > 0) {
-        as.list(.from_Seurat_guess_varps(obj))
-      } else {
-        FALSE
-      },
-      uns_mapping = if (length(as.list(.from_Seurat_guess_uns(obj))) > 0) {
-        as.list(.from_Seurat_guess_uns(obj))
-      } else {
-        FALSE
-      }
+    expect_warning(
+      as_AnnData(
+        obj,
+        layers_mapping = as.list(.from_Seurat_guess_layers(obj, active_assay)),
+        obs_mapping = as.list(.from_Seurat_guess_obs(obj, active_assay)),
+        var_mapping = as.list(.from_Seurat_guess_var(obj, active_assay)),
+        obsm_mapping = as.list(.from_Seurat_guess_obsms(obj, active_assay)),
+        varm_mapping = as.list(.from_Seurat_guess_varms(obj, active_assay)),
+        obsp_mapping = as.list(.from_Seurat_guess_obsps(obj, active_assay)),
+        varp_mapping = if (length(as.list(.from_Seurat_guess_varps(obj))) > 0) {
+          as.list(.from_Seurat_guess_varps(obj))
+        } else {
+          FALSE
+        },
+        uns_mapping = if (length(as.list(.from_Seurat_guess_uns(obj))) > 0) {
+          as.list(.from_Seurat_guess_uns(obj))
+        } else {
+          FALSE
+        }
+      ),
+      regexp = "Row names of a varm matrix coming from Seurat do not match the var names"
     )
   )
 })
@@ -225,21 +232,24 @@ test_that("as_AnnData (Seurat) works with list mappings", {
 test_that("as_AnnData (Seurat) works with unnamed mappings", {
   active_assay <- SeuratObject::DefaultAssay(obj)
   expect_no_error(
-    as_AnnData(
-      obj,
-      layers_mapping = unname(.from_Seurat_guess_layers(obj, active_assay)),
-      obs_mapping = unname(.from_Seurat_guess_obs(obj, active_assay)),
-      var_mapping = unname(.from_Seurat_guess_var(obj, active_assay)),
-      obsm_mapping = unname(.from_Seurat_guess_obsms(obj, active_assay)),
-      varm_mapping = unname(.from_Seurat_guess_varms(obj, active_assay)),
-      obsp_mapping = unname(.from_Seurat_guess_obsps(obj, active_assay)),
-      varp_mapping = unname(.from_Seurat_guess_varps(obj)) %||% FALSE,
-      uns_mapping = unname(.from_Seurat_guess_uns(obj)) %||% FALSE
+    expect_warning(
+      as_AnnData(
+        obj,
+        layers_mapping = unname(.from_Seurat_guess_layers(obj, active_assay)),
+        obs_mapping = unname(.from_Seurat_guess_obs(obj, active_assay)),
+        var_mapping = unname(.from_Seurat_guess_var(obj, active_assay)),
+        obsm_mapping = unname(.from_Seurat_guess_obsms(obj, active_assay)),
+        varm_mapping = unname(.from_Seurat_guess_varms(obj, active_assay)),
+        obsp_mapping = unname(.from_Seurat_guess_obsps(obj, active_assay)),
+        varp_mapping = unname(.from_Seurat_guess_varps(obj)) %||% FALSE,
+        uns_mapping = unname(.from_Seurat_guess_uns(obj)) %||% FALSE
+      ),
+      regexp = "Row names of a varm matrix coming from Seurat do not match the var names"
     )
   )
 })
 
 test_that("as_AnnData (Seurat) works with empty mappings", {
-  expect_warning(as_AnnData(obj, layers_mapping = NULL), "argument is empty")
-  expect_warning(as_AnnData(obj, layers_mapping = c()), "argument is empty")
+  expect_warning(as_AnnData(obj, varm_mapping = NULL), regexp = "argument is empty")
+  expect_warning(as_AnnData(obj, varm_mapping = c()), regexp = "argument is empty")
 })

--- a/tests/testthat/test-from_SingleCellExperiment.R
+++ b/tests/testthat/test-from_SingleCellExperiment.R
@@ -100,9 +100,15 @@ for (obsp_key in names(colPairs(sce))) {
     skip_if(!is.null(msg), message = msg)
 
     expect_true(obsp_key %in% names(ad$obsp))
+    # AnnData now adds dimnames on-the-fly, but SCE doesn't preserve them
+    # So we need to strip dimnames for comparison
+    actual_mat <- ad$obsp[[obsp_key]]
+    expected_mat <- colPairs(sce, asSparse = TRUE)[[obsp_key]]
+    dimnames(actual_mat) <- NULL
+    dimnames(expected_mat) <- NULL
     expect_equal(
-      ad$obsp[[obsp_key]],
-      colPairs(sce, asSparse = TRUE)[[obsp_key]],
+      actual_mat,
+      expected_mat,
       ignore_attr = TRUE,
       info = paste0("obsp_key: ", obsp_key)
     )
@@ -122,9 +128,15 @@ for (varp_key in names(rowPairs(sce))) {
     skip_if(!is.null(msg), message = msg)
 
     expect_true(varp_key %in% names(ad$varp))
+    # AnnData now adds dimnames on-the-fly, but SCE doesn't preserve them
+    # So we need to strip dimnames for comparison
+    actual_mat <- ad$varp[[varp_key]]
+    expected_mat <- rowPairs(sce, asSparse = TRUE)[[varp_key]]
+    dimnames(actual_mat) <- NULL
+    dimnames(expected_mat) <- NULL
     expect_equal(
-      ad$varp[[varp_key]],
-      rowPairs(sce, asSparse = TRUE)[[varp_key]],
+      actual_mat,
+      expected_mat,
       info = paste0("varp_key: ", varp_key)
     )
   })
@@ -170,9 +182,15 @@ test_that("as_AnnData (SCE) retains pca dimred", {
 
   # trackstatus: class=SingleCellExperiment, feature=test_set_varm, status=wip
   expect_true("X_pca" %in% names(ad$varm))
+  # AnnData now adds dimnames on-the-fly, but SCE doesn't preserve them
+  # So we need to strip dimnames for comparison
+  actual_mat <- ad$varm[["X_pca"]]
+  expected_mat <- featureLoadings(reducedDims(sce)$X_pca)
+  dimnames(actual_mat) <- NULL
+  dimnames(expected_mat) <- NULL
   expect_equal(
-    featureLoadings(reducedDims(sce)$X_pca),
-    ad$varm[["X_pca"]]
+    expected_mat,
+    actual_mat
   )
 })
 

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -80,14 +80,14 @@ for (name in test_names) {
 
       # Extract X matrices, removing dimnames for comparison since
       # R AnnData adds dimnames on-the-fly but Python doesn't preserve them
-      actual_X <- adata_r$X
-      expected_X <- py_to_r(adata_py$X)
-      dimnames(actual_X) <- NULL
-      dimnames(expected_X) <- NULL
+      actual_x <- adata_r$X
+      expected_x <- py_to_r(adata_py$X)
+      dimnames(actual_x) <- NULL
+      dimnames(expected_x) <- NULL
 
       expect_equal(
-        actual_X,
-        expected_X,
+        actual_x,
+        expected_x,
         tolerance = 1e-6
       )
     }

--- a/tests/testthat/test-roundtrip-X.R
+++ b/tests/testthat/test-roundtrip-X.R
@@ -78,9 +78,16 @@ for (name in test_names) {
 
       adata_r <- read_h5ad(file_py, as = "HDF5AnnData")
 
+      # Extract X matrices, removing dimnames for comparison since
+      # R AnnData adds dimnames on-the-fly but Python doesn't preserve them
+      actual_X <- adata_r$X
+      expected_X <- py_to_r(adata_py$X)
+      dimnames(actual_X) <- NULL
+      dimnames(expected_X) <- NULL
+
       expect_equal(
-        adata_r$X,
-        py_to_r(adata_py$X),
+        actual_X,
+        expected_X,
         tolerance = 1e-6
       )
     }

--- a/tests/testthat/test-roundtrip-layers.R
+++ b/tests/testthat/test-roundtrip-layers.R
@@ -88,9 +88,16 @@ for (name in test_names) {
 
       adata_r <- read_h5ad(file_py, as = "HDF5AnnData")
 
+      # R AnnData now adds dimnames on-the-fly, but Python doesn't preserve them
+      # So we need to strip dimnames for comparison
+      actual_mat <- adata_r$layers[[name]]
+      expected_mat <- py_to_r(py_get_item(adata_py$layers, name))
+      dimnames(actual_mat) <- NULL
+      dimnames(expected_mat) <- NULL
+
       expect_equal(
-        adata_r$layers[[name]],
-        py_to_r(py_get_item(adata_py$layers, name)),
+        actual_mat,
+        expected_mat,
         tolerance = 1e-6
       )
     }

--- a/tests/testthat/test-roundtrip-obsmvarm.R
+++ b/tests/testthat/test-roundtrip-obsmvarm.R
@@ -110,14 +110,27 @@ for (name in test_names) {
 
       adata_r <- read_h5ad(file_py, as = "HDF5AnnData")
 
+      # R AnnData now adds dimnames on-the-fly, but Python doesn't preserve them
+      # So we need to strip dimnames for comparison
+      actual_obsm <- adata_r$obsm[[name]]
+      expected_obsm <- py_to_r(py_get_item(adata_py$obsm, name))
+      dimnames(actual_obsm) <- NULL
+      dimnames(expected_obsm) <- NULL
+
       expect_equal(
-        adata_r$obsm[[name]],
-        py_to_r(py_get_item(adata_py$obsm, name)),
+        actual_obsm,
+        expected_obsm,
         tolerance = 1e-6
       )
+
+      actual_varm <- adata_r$varm[[name]]
+      expected_varm <- py_to_r(py_get_item(adata_py$varm, name))
+      dimnames(actual_varm) <- NULL
+      dimnames(expected_varm) <- NULL
+
       expect_equal(
-        adata_r$varm[[name]],
-        py_to_r(py_get_item(adata_py$varm, name)),
+        actual_varm,
+        expected_varm,
         tolerance = 1e-6
       )
     }

--- a/tests/testthat/test-roundtrip-obspvarp.R
+++ b/tests/testthat/test-roundtrip-obspvarp.R
@@ -93,14 +93,27 @@ for (name in test_names) {
 
       adata_r <- read_h5ad(file_py, as = "HDF5AnnData")
 
+      # R AnnData now adds dimnames on-the-fly, but Python doesn't preserve them
+      # So we need to strip dimnames for comparison
+      actual_obsp <- adata_r$obsp[[name]]
+      expected_obsp <- py_to_r(py_get_item(adata_py$obsp, name))
+      dimnames(actual_obsp) <- NULL
+      dimnames(expected_obsp) <- NULL
+
       expect_equal(
-        adata_r$obsp[[name]],
-        py_to_r(py_get_item(adata_py$obsp, name)),
+        actual_obsp,
+        expected_obsp,
         tolerance = 1e-6
       )
+
+      actual_varp <- adata_r$varp[[name]]
+      expected_varp <- py_to_r(py_get_item(adata_py$varp, name))
+      dimnames(actual_varp) <- NULL
+      dimnames(expected_varp) <- NULL
+
       expect_equal(
-        adata_r$varp[[name]],
-        py_to_r(py_get_item(adata_py$varp, name)),
+        actual_varp,
+        expected_varp,
         tolerance = 1e-6
       )
     }


### PR DESCRIPTION
**Related to:** <!-- Add links to related issues etc. here -->

## Description

#324 is starting to accumulate a lot of different, somewhat related changes. I'm going to split it up a bit to try to make the review process a bit easier.

### Minor changes

- Refactor setter methods in `HDF5AnnData` and `InMemoryAnnData` to use pipe 
  operators for cleaner code
- Add explanatory comments for matrix generation alignment with dummy-anndata 


### Bug fixes

- Add compression parameter to additional write operations in `HDF5AnnData` 
  for consistency
- Directly use `obs_names` and `var_names` properties instead of corresponding
  indirect S3 methods `rownames` and `colnames`
- Fix error message variable name in `.validate_aligned_array()` method 
  (expected_colnames → expected_rownames)


## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [ ] Bump devel version
