### PR TITLE
Avoid creating character datasets with LZF filter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,8 @@
   - Seurat PCA loadings only contain variable features, not all genes
   - Now properly expands loadings matrix to include all genes with zeros for non-variable features
   - Adds warning when rownames don't match var_names during conversion
+- Avoid writing character datasets to H5AD files with LZF compression as it
+  causes R to crash (PR #356)
 
 ## Documentation
 

--- a/R/write_hdf5_helpers.R
+++ b/R/write_hdf5_helpers.R
@@ -27,6 +27,12 @@ hdf5_write_dataset <- function(
     dims <- length(value)
   }
 
+  # Avoid segfault when creating a character dataset with LZF compression,
+  # see https://github.com/Huber-group-EMBL/rhdf5/issues/168
+  if (compression == "lzf" && (storage.mode(value) == "character")) {
+    compression <- "none"
+  }
+
   rhdf5::h5createDataset(
     file,
     name,

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -237,27 +237,24 @@ test_that("writing gzip compressed files works", {
   expect_true(file.info(h5ad_file_none)$size > file.info(h5ad_file_gzip)$size)
 })
 
-# TODO: re-enable these tests
-# nolint start
-# test_that("writing lzf compressed files works", {
-#   dummy <- generate_dataset(100, 200, example = FALSE)
-#   non_random_X <- matrix(5, 100, 200) # nolint
-#
-#   adata <- AnnData(
-#     X = non_random_X,
-#     obs = dummy$obs,
-#     var = dummy$var
-#   )
-#
-#   h5ad_file_none <- tempfile(pattern = "hdf5_write_none_", fileext = ".h5ad")
-#   h5ad_file_lzf <- tempfile(pattern = "hdf5_write_lzf_", fileext = ".h5ad")
-#
-#   write_h5ad(adata, h5ad_file_none, compression = "none")
-#   write_h5ad(adata, h5ad_file_lzf, compression = "lzf")
-#
-#   expect_true(file.info(h5ad_file_none)$size > file.info(h5ad_file_lzf)$size)
-# })
-# nolint end
+test_that("writing lzf compressed files works", {
+  dummy <- generate_dataset(100, 200, example = FALSE)
+  non_random_X <- matrix(5, 100, 200) # nolint
+
+  adata <- AnnData(
+    X = non_random_X,
+    obs = dummy$obs,
+    var = dummy$var
+  )
+
+  h5ad_file_none <- tempfile(pattern = "hdf5_write_none_", fileext = ".h5ad")
+  h5ad_file_lzf <- tempfile(pattern = "hdf5_write_lzf_", fileext = ".h5ad")
+
+  write_h5ad(adata, h5ad_file_none, compression = "none")
+  write_h5ad(adata, h5ad_file_lzf, compression = "lzf")
+
+  expect_true(file.info(h5ad_file_none)$size > file.info(h5ad_file_lzf)$size)
+})
 
 test_that("write_h5ad() gives consistent hashes", {
   dummy <- generate_dataset(100, 200, example = TRUE, format = "AnnData")


### PR DESCRIPTION
**Related to:** Fixes #340 

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Add a check to `hdf5_write_dataset()` to avoid creating an LZF compressed character dataset which causes a segfault. See https://github.com/Huber-group-EMBL/rhdf5/issues/168 for details.

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [x] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [ ] Bump devel version
