### PR TITLE
Improve handling in conversion from `Seurat`

### DIFF
--- a/R/as_AnnData.R
+++ b/R/as_AnnData.R
@@ -6,39 +6,31 @@
 #'
 #' @param x The object to convert
 #' @param x_mapping A string specifying the data to map to the `X` slot. If
-#'   `NULL`, no data will be copied to the `X` slot.
+#'   `NULL`, no data will be copied to the `X` slot. See below for details.
 #' @param layers_mapping A named character vector where the names are keys of
 #'   `layers` in the new `AnnData` object and values are the names of items in
-#'   the corresponding slot of `x`. See below for default if `NULL` depending on
-#'   the class of `x`.
+#'   the corresponding slot of `x`. See below for details.
 #' @param obs_mapping A named character vector where the names are names of
 #'   `obs` columns in the new `AnnData` object and values are the names of
-#'   columns in the corresponding slot of `x`. See below for default if `NULL`
-#'   depending on the class of `x`.
+#'   columns in the corresponding slot of `x`. See below for details.
 #' @param var_mapping A named character vector where the names are names of
 #'   `var` columns in the new `AnnData` object and values are the names of
-#'   columns in the corresponding slot of `x`. See below for default if `NULL`
-#'   depending on the class of `x`.
+#'   columns in the corresponding slot of `x`. See below for details.
 #' @param obsm_mapping A named character vector where the names are keys of
 #'   `obsm` in the new `AnnData` object and values are the names of items in the
-#'   corresponding slot of `x`. See below for default if `NULL` depending on the
-#'   class of `x`.
+#'   corresponding slot of `x`. See below for details.
 #' @param varm_mapping A named character vector where the names are keys of
 #'   `varm` in the new `AnnData` object and values are the names of items in the
-#'   corresponding slot of `x`. See below for default if `NULL` depending on the
-#'   class of `x`.
+#'   corresponding slot of `x`. See below for details.
 #' @param obsp_mapping A named character vector where the names are keys of
 #'   `obsp` in the new `AnnData` object and values are the names of items in the
-#'   corresponding slot of `x`. See below for default if `NULL` depending on the
-#'   class of `x`.
+#'   corresponding slot of `x`. See below for details.
 #' @param varp_mapping A named character vector where the names are keys of
 #'   `varp` in the new `AnnData` object and values are the names of items in the
-#'   corresponding slot of `x`. See below for default if `NULL` depending on the
-#'   class of `x`.
+#'   corresponding slot of `x`. See below for details.
 #' @param uns_mapping A named character vector where the names are keys of `uns`
 #'   in the new `AnnData` object and values are the names of items in the
-#'   corresponding slot of `x`. See below for default if `NULL` depending on the
-#'   class of `x`.
+#'   corresponding slot of `x`. See below for details.
 #' @param assay_name For [`SeuratObject::Seurat`] objects, the name of the assay
 #'   to be converted. If `NULL`, the default assay will be used
 #'   ([SeuratObject::DefaultAssay()]). This is ignored for other objects.
@@ -75,7 +67,7 @@
 #'
 # nolint start: line_length_linter
 #'
-#'   | **From `SingleCellExperiment`** | **To `AnnData`** | **Example mapping argument** | **Default if `NULL`** |
+#'   | **From `SingleCellExperiment`** | **To `AnnData`** | **Example mapping argument** | **Default** |
 #'   |---------------------------------|------------------|------------------------------|-----------------------|
 #'   | `assays(x)` | `adata$X` | `x_mapping = "counts"` | Nothing is copied to `X` |
 #'   | `assays(x)` | `adata$layers` | `layers_mapping = c(counts = "counts")` | All items are copied by name |
@@ -101,7 +93,7 @@
 #'
 # nolint start: line_length_linter
 #'
-#'   | **From `Seurat`** | **To `AnnData`** | **Example mapping argument** | **Default if `NULL`** |
+#'   | **From `Seurat`** | **To `AnnData`** | **Example mapping argument** | **Default** |
 #'   |-------------------|------------------|------------------------------|-----------------------|
 #'   | `Layers(x)` | `adata$X` | `x_mapping = "counts"` | Nothing is copied to `X` |
 #'   | `Layers(x)` | `adata$layers` | `layers_mapping = c(counts = "counts")` | All items are copied by name |

--- a/R/as_AnnData.R
+++ b/R/as_AnnData.R
@@ -115,6 +115,20 @@
 #'
 # nolint end: line_length_linter
 #'
+#'   ## Graph conversion
+#'
+#'   By default, all graphs in a `Seurat` object that match the assay being
+#'   converted are copied to the `obsp` slot of the new `AnnData` object. If a
+#'   graph does not have an associated assay:
+#'
+#'   - If `assay_name` is the default assay, they will be _converted_ with a
+#'     warning
+#'   - if `assay_name` is not the default assay, they will be _skipped_ with a
+#'     warning
+#'
+#'   To override this behavior, provide a custom mapping using the
+#'   `obsp_mapping` argument.
+#'
 #' @return An `AnnData` object of the class requested by `output_class`
 #'   containing the data specified in the mapping arguments.
 #' @export

--- a/R/as_AnnData.R
+++ b/R/as_AnnData.R
@@ -107,7 +107,7 @@
 #'   | `Layers(x)` | `adata$layers` | `layers_mapping = c(counts = "counts")` | All items are copied by name |
 #'   | `x[[]]` | `adata$obs` | `obs_mapping = c(n_counts = "n_counts", cell_type = "CellType")` | All columns are copied by name |
 #'   | `x[[assay_name]][[]]` | `adata$var` | `var_mapping = c(n_cells = "n_cells", pct_zero = "PctZero")` | All columns are copied by name |
-#'   | `Embeddings(x)` | `adata$obsm` | `obsm_mapping = c(X_pca = "pca")` | All embeddings matching `assay_name` are copied by name |
+#'   | `Reductions(x)` | `adata$obsm` | `obsm_mapping = c(X_pca = "pca")` | All embeddings matching `assay_name` are copied by name |
 #'   | `Loadings(x)` | `adata$varm` | `varm_mapping = c(PCs = "pca")` | All valid loadings are copied by name |
 #'   | `Graphs(x)` | `adata$obsp` | `obsp_mapping = c(connectivities = "RNA_nn")` | All graphs matching `assay_name` are copied by name |
 #'   | `Misc(x)` | `adata$varp` | `varp_mapping = c(similarities = "gene_overlaps")` | No data is copied to `varp` |
@@ -117,9 +117,9 @@
 #'
 #'   ## Graph conversion
 #'
-#'   By default, all graphs in a `Seurat` object that match the assay being
-#'   converted are copied to the `obsp` slot of the new `AnnData` object. If a
-#'   graph does not have an associated assay:
+#'   By default, all graphs in a [`SeuratObject::Seurat`] object that match the
+#'   assay being converted are copied to the `obsp` slot of the new `AnnData`
+#'   object. If a graph does not have an associated assay:
 #'
 #'   - If `assay_name` is the default assay, they will be _converted_ with a
 #'     warning
@@ -128,6 +128,13 @@
 #'
 #'   To override this behavior, provide a custom mapping using the
 #'   `obsp_mapping` argument.
+#'
+#'   ## Unexpected dimensions
+#'
+#'   A [`SeuratObject::Seurat`] is more flexible in terms of the dimensions of
+#'   items that can be stored in various slots. For example, a `Layer` does not
+#'   have to match the dimensions of the whole object. If an item has
+#'   unexpected dimensions, it will be skipped with a warning.
 #'
 #' @return An `AnnData` object of the class requested by `output_class`
 #'   containing the data specified in the mapping arguments.

--- a/R/as_Seurat.R
+++ b/R/as_Seurat.R
@@ -57,7 +57,7 @@
 #'
 # nolint start: line_length_linter
 #'
-#' | **From `AnnData`** | **To `Seurat`** | **Example mapping argument** | **Default if `NULL`** |
+#' | **From `AnnData`** | **To `Seurat`** | **Example mapping argument** | **Default** |
 #' |--------------------|-------------------------------|------------------------------|-----------------------|
 #' | `adata$X` | `Layers(seurat)` | `x_mapping = "counts"` _OR_ `layers_mapping = c(counts = NA)` | The data in `adata$X` is copied to a layer named `X` |
 #' | `adata$layers` | `Layers(seurat)` | `layers_mapping = c(counts = "counts")` | All items are copied by name |

--- a/R/as_SingleCellExperiment.R
+++ b/R/as_SingleCellExperiment.R
@@ -61,7 +61,7 @@
 #'
 # nolint start: line_length_linter
 #'
-#' | **From `AnnData`** | **To `SingleCellExperiment`** | **Example mapping argument** | **Default if `NULL`** |
+#' | **From `AnnData`** | **To `SingleCellExperiment`** | **Example mapping argument** | **Default** |
 #' |--------------------|-------------------------------|------------------------------|-----------------------|
 #' | `adata$X` | `assays(sce)` | `x_mapping = "counts"` | The data in `adata$X` is copied to the assay named `X` |
 #' | `adata$layers` | `assays(sce)` | `assays_mapping = c(counts = "counts")` | All items are copied by name |

--- a/R/from_Seurat.R
+++ b/R/from_Seurat.R
@@ -254,11 +254,11 @@ from_Seurat <- function(
       expected_dims = rev(dim(adata))
     )
 
-    if (!is.null(layer_data)) {
-      to_py_matrix(layer_data)
+    if (is.null(layer_data)) {
+      return(NULL)
     }
 
-    layer_data
+    to_py_matrix(layer_data)
   })
 }
 

--- a/R/from_Seurat.R
+++ b/R/from_Seurat.R
@@ -460,8 +460,26 @@ from_Seurat <- function(
 
   for (graph_name in SeuratObject::Graphs(seurat_obj)) {
     graph <- seurat_obj[[graph_name]]
+    graph_assay <- SeuratObject::DefaultAssay(graph)
 
-    if (SeuratObject::DefaultAssay(graph) != assay_name) {
+    # Handle graphs with missing assay information
+    if (is.null(graph_assay)) {
+      # If we are using the default assay, warn and convert
+      if (assay_name == SeuratObject::DefaultAssay(seurat_obj)) {
+        cli_warn(c(
+          "Graph {.val {graph_name}} does not have an associated assay",
+          "i" = "Assuming it belongs to the selected default assay ({.val {assay_name}})"
+        ))
+      } else {
+        # If another assay, warn and don't convert
+        cli_warn(c(
+          "Graph {.val {graph_name}} does not have an associated assay",
+          "i" = "Assuming it does not belong to the selected assay ({.val {assay_name}}) and skipping"
+        ))
+        next
+      }
+    } else if (graph_assay != assay_name) {
+      # Skip graphs from other assays
       next
     }
 

--- a/R/from_Seurat.R
+++ b/R/from_Seurat.R
@@ -247,9 +247,18 @@ from_Seurat <- function(
   }
 
   adata$layers <- purrr::map(layers_mapping, function(.layer) {
-    to_py_matrix(
-      SeuratObject::LayerData(seurat_obj, assay = assay_name, layer = .layer)
+    layer_data <- check_dims_and_skip(
+      SeuratObject::LayerData(seurat_obj, assay = assay_name, layer = .layer),
+      "Layer",
+      .layer,
+      expected_dims = rev(dim(adata))
     )
+
+    if (!is.null(layer_data)) {
+      to_py_matrix(layer_data)
+    }
+
+    layer_data
   })
 }
 
@@ -273,7 +282,13 @@ from_Seurat <- function(
         "i" = "Available reductions: {.val {SeuratObject::Reductions(seurat_obj)}}"
       ))
     }
-    SeuratObject::Embeddings(seurat_obj, .reduction)
+
+    check_dims_and_skip(
+      SeuratObject::Embeddings(seurat_obj, .reduction),
+      "Reduction",
+      .reduction,
+      expected_rows = nrow(adata)
+    )
   })
 }
 
@@ -337,7 +352,19 @@ from_Seurat <- function(
         "i" = "Available graphs: {.val {SeuratObject::Graphs(seurat_obj)}}"
       ))
     }
-    as(seurat_obj[[.graph]], "sparseMatrix")
+
+    graph_data <- check_dims_and_skip(
+      seurat_obj[[.graph]],
+      "Graph",
+      .graph,
+      expected_dims = c(nrow(adata), nrow(adata))
+    )
+
+    if (is.null(graph_data)) {
+      return(NULL)
+    }
+
+    as(graph_data, "sparseMatrix")
   })
 }
 
@@ -362,7 +389,19 @@ from_Seurat <- function(
         "i" = "Available misc data: {.val {names(SeuratObject::Misc(seurat_obj))}}"
       ))
     }
-    SeuratObject::Misc(seurat_obj, .varp)
+
+    varp_data <- check_dims_and_skip(
+      SeuratObject::Misc(seurat_obj, .varp),
+      "Misc",
+      .varp,
+      expected_dims = c(ncol(adata), ncol(adata))
+    )
+
+    if (is.null(varp_data)) {
+      return(NULL)
+    }
+
+    as(varp_data, "sparseMatrix")
   })
 }
 

--- a/R/ui.R
+++ b/R/ui.R
@@ -4,7 +4,7 @@
 #'
 #' @param x The vector to style
 #' @param last The separator before the last element in the vector
-#' @param trunc The maxium number of elements to show
+#' @param trunc The maximum number of elements to show
 #' @param trunc_style The truncation style to use, either "both-ends"
 #'   (1, 2, ..., n-1, 1) or "head" (1, 2, 3, 4, ...)
 #' @param wrap Whether to wrap the output to appear as a vector, if `TRUE` then
@@ -23,6 +23,7 @@ style_vec <- function(
 
   style <- list(
     "vec-last" = last,
+    "vec-sep2" = last,
     "vec-trunc" = trunc,
     "vec-trunc-style" = trunc_style
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -159,7 +159,6 @@ check_dims_and_skip <- function(
   expected_rows = NULL,
   expected_cols = NULL
 ) {
-
   msg <- NULL
 
   if (!is.null(expected_dims) && !identical(dim(x), expected_dims)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -134,3 +134,67 @@ get_mapping <- function(mapping, guesser, obj, name, ...) {
   # Make sure provided mapping has names
   self_name(mapping)
 }
+
+#' Check dimensions and skip
+#'
+#' Check the dimensions of a matrix-like object and return `NULL` if they do not
+#' match the expected dimensions, with a warning. For use in conversion
+#' functions to skip items that do not match the required dimensions.
+#'
+#' @param x The object to check
+#' @param field The field the object comes from, used in the warning message
+#' @param name The name of the object, used in the warning message
+#' @param expected_dims Expected dimensions
+#' @param expected_rows Expected number of rows
+#' @param expected_cols Expected number of columns
+#'
+#' @returns The object `x` if it matches the expected dimensions, otherwise
+#'   `NULL`
+#' @noRd
+check_dims_and_skip <- function(
+  x,
+  field,
+  name,
+  expected_dims = NULL,
+  expected_rows = NULL,
+  expected_cols = NULL
+) {
+
+  msg <- NULL
+
+  if (!is.null(expected_dims) && !identical(dim(x), expected_dims)) {
+    expected_dims <- as.integer(expected_dims)
+    msg <- c(
+      "i" = paste0(
+        "Expected [{style_vec(expected_dims)}], ",
+        "got [{style_vec(as.integer(dim(x)))}]"
+      )
+    )
+  } else if (!is.null(expected_rows) && nrow(x) != expected_rows) {
+    msg <- c(
+      "i" = paste0(
+        "Expected {.val {expected_rows}} rows, got {.val {nrow(x)}}"
+      )
+    )
+  } else if (!is.null(expected_cols) && ncol(x) != expected_cols) {
+    msg <- c(
+      "i" = paste0(
+        "Expected {.val {expected_cols}} colums, got {.val {ncol(x)}}"
+      )
+    )
+  }
+
+  if (!is.null(msg)) {
+    cli_warn(
+      c(
+        "Skipping {.field {field}} {.val {name}} with unexpected dimensions",
+        msg
+      ),
+      call = NULL
+    )
+
+    return(NULL)
+  } else {
+    return(x)
+  }
+}

--- a/man/as_AnnData.Rd
+++ b/man/as_AnnData.Rd
@@ -58,47 +58,39 @@ as_AnnData(
 \item{x}{The object to convert}
 
 \item{x_mapping}{A string specifying the data to map to the \code{X} slot. If
-\code{NULL}, no data will be copied to the \code{X} slot.}
+\code{NULL}, no data will be copied to the \code{X} slot. See below for details.}
 
 \item{layers_mapping}{A named character vector where the names are keys of
 \code{layers} in the new \code{AnnData} object and values are the names of items in
-the corresponding slot of \code{x}. See below for default if \code{NULL} depending on
-the class of \code{x}.}
+the corresponding slot of \code{x}. See below for details.}
 
 \item{obs_mapping}{A named character vector where the names are names of
 \code{obs} columns in the new \code{AnnData} object and values are the names of
-columns in the corresponding slot of \code{x}. See below for default if \code{NULL}
-depending on the class of \code{x}.}
+columns in the corresponding slot of \code{x}. See below for details.}
 
 \item{var_mapping}{A named character vector where the names are names of
 \code{var} columns in the new \code{AnnData} object and values are the names of
-columns in the corresponding slot of \code{x}. See below for default if \code{NULL}
-depending on the class of \code{x}.}
+columns in the corresponding slot of \code{x}. See below for details.}
 
 \item{obsm_mapping}{A named character vector where the names are keys of
 \code{obsm} in the new \code{AnnData} object and values are the names of items in the
-corresponding slot of \code{x}. See below for default if \code{NULL} depending on the
-class of \code{x}.}
+corresponding slot of \code{x}. See below for details.}
 
 \item{varm_mapping}{A named character vector where the names are keys of
 \code{varm} in the new \code{AnnData} object and values are the names of items in the
-corresponding slot of \code{x}. See below for default if \code{NULL} depending on the
-class of \code{x}.}
+corresponding slot of \code{x}. See below for details.}
 
 \item{obsp_mapping}{A named character vector where the names are keys of
 \code{obsp} in the new \code{AnnData} object and values are the names of items in the
-corresponding slot of \code{x}. See below for default if \code{NULL} depending on the
-class of \code{x}.}
+corresponding slot of \code{x}. See below for details.}
 
 \item{varp_mapping}{A named character vector where the names are keys of
 \code{varp} in the new \code{AnnData} object and values are the names of items in the
-corresponding slot of \code{x}. See below for default if \code{NULL} depending on the
-class of \code{x}.}
+corresponding slot of \code{x}. See below for details.}
 
 \item{uns_mapping}{A named character vector where the names are keys of \code{uns}
 in the new \code{AnnData} object and values are the names of items in the
-corresponding slot of \code{x}. See below for default if \code{NULL} depending on the
-class of \code{x}.}
+corresponding slot of \code{x}. See below for details.}
 
 \item{assay_name}{For \code{\link[SeuratObject:Seurat-class]{SeuratObject::Seurat}} objects, the name of the assay
 to be converted. If \code{NULL}, the default assay will be used
@@ -148,7 +140,7 @@ tables for each object type
 This table describes how slots in a
 \code{\link[SingleCellExperiment:SingleCellExperiment]{SingleCellExperiment::SingleCellExperiment}} object to the new \code{AnnData}
 object.\tabular{llll}{
-   \strong{From \code{SingleCellExperiment}} \tab \strong{To \code{AnnData}} \tab \strong{Example mapping argument} \tab \strong{Default if \code{NULL}} \cr
+   \strong{From \code{SingleCellExperiment}} \tab \strong{To \code{AnnData}} \tab \strong{Example mapping argument} \tab \strong{Default} \cr
    \code{assays(x)} \tab \code{adata$X} \tab \code{x_mapping = "counts"} \tab Nothing is copied to \code{X} \cr
    \code{assays(x)} \tab \code{adata$layers} \tab \code{layers_mapping = c(counts = "counts")} \tab All items are copied by name \cr
    \code{colData(x)} \tab \code{adata$obs} \tab \code{obs_mapping = c(n_counts = "n_counts", cell_type = "CellType")} \tab All columns are copied by name \cr
@@ -170,7 +162,7 @@ an \code{AnnData} object at a time. This can be controlled using the
 
 This table describes how slots in a \code{\link[SeuratObject:Seurat-class]{SeuratObject::Seurat}} object to the
 new \code{AnnData} object.\tabular{llll}{
-   \strong{From \code{Seurat}} \tab \strong{To \code{AnnData}} \tab \strong{Example mapping argument} \tab \strong{Default if \code{NULL}} \cr
+   \strong{From \code{Seurat}} \tab \strong{To \code{AnnData}} \tab \strong{Example mapping argument} \tab \strong{Default} \cr
    \code{Layers(x)} \tab \code{adata$X} \tab \code{x_mapping = "counts"} \tab Nothing is copied to \code{X} \cr
    \code{Layers(x)} \tab \code{adata$layers} \tab \code{layers_mapping = c(counts = "counts")} \tab All items are copied by name \cr
    \code{x[[]]} \tab \code{adata$obs} \tab \code{obs_mapping = c(n_counts = "n_counts", cell_type = "CellType")} \tab All columns are copied by name \cr

--- a/man/as_AnnData.Rd
+++ b/man/as_AnnData.Rd
@@ -175,7 +175,7 @@ new \code{AnnData} object.\tabular{llll}{
    \code{Layers(x)} \tab \code{adata$layers} \tab \code{layers_mapping = c(counts = "counts")} \tab All items are copied by name \cr
    \code{x[[]]} \tab \code{adata$obs} \tab \code{obs_mapping = c(n_counts = "n_counts", cell_type = "CellType")} \tab All columns are copied by name \cr
    \code{x[[assay_name]][[]]} \tab \code{adata$var} \tab \code{var_mapping = c(n_cells = "n_cells", pct_zero = "PctZero")} \tab All columns are copied by name \cr
-   \code{Embeddings(x)} \tab \code{adata$obsm} \tab \code{obsm_mapping = c(X_pca = "pca")} \tab All embeddings matching \code{assay_name} are copied by name \cr
+   \code{Reductions(x)} \tab \code{adata$obsm} \tab \code{obsm_mapping = c(X_pca = "pca")} \tab All embeddings matching \code{assay_name} are copied by name \cr
    \code{Loadings(x)} \tab \code{adata$varm} \tab \code{varm_mapping = c(PCs = "pca")} \tab All valid loadings are copied by name \cr
    \code{Graphs(x)} \tab \code{adata$obsp} \tab \code{obsp_mapping = c(connectivities = "RNA_nn")} \tab All graphs matching \code{assay_name} are copied by name \cr
    \code{Misc(x)} \tab \code{adata$varp} \tab \code{varp_mapping = c(similarities = "gene_overlaps")} \tab No data is copied to \code{varp} \cr
@@ -184,9 +184,9 @@ new \code{AnnData} object.\tabular{llll}{
 
 \subsection{Graph conversion}{
 
-By default, all graphs in a \code{Seurat} object that match the assay being
-converted are copied to the \code{obsp} slot of the new \code{AnnData} object. If a
-graph does not have an associated assay:
+By default, all graphs in a \code{\link[SeuratObject:Seurat-class]{SeuratObject::Seurat}} object that match the
+assay being converted are copied to the \code{obsp} slot of the new \code{AnnData}
+object. If a graph does not have an associated assay:
 \itemize{
 \item If \code{assay_name} is the default assay, they will be \emph{converted} with a
 warning
@@ -196,6 +196,14 @@ warning
 
 To override this behavior, provide a custom mapping using the
 \code{obsp_mapping} argument.
+}
+
+\subsection{Unexpected dimensions}{
+
+A \code{\link[SeuratObject:Seurat-class]{SeuratObject::Seurat}} is more flexible in terms of the dimensions of
+items that can be stored in various slots. For example, a \code{Layer} does not
+have to match the dimensions of the whole object. If an item has
+unexpected dimensions, it will be skipped with a warning.
 }
 }
 

--- a/man/as_AnnData.Rd
+++ b/man/as_AnnData.Rd
@@ -181,6 +181,22 @@ new \code{AnnData} object.\tabular{llll}{
    \code{Misc(x)} \tab \code{adata$varp} \tab \code{varp_mapping = c(similarities = "gene_overlaps")} \tab No data is copied to \code{varp} \cr
    \code{Misc(x)} \tab \code{adata$uns} \tab \code{uns_mapping = c(metadata = "project_metadata")} \tab All items are copied by name \cr
 }
+
+\subsection{Graph conversion}{
+
+By default, all graphs in a \code{Seurat} object that match the assay being
+converted are copied to the \code{obsp} slot of the new \code{AnnData} object. If a
+graph does not have an associated assay:
+\itemize{
+\item If \code{assay_name} is the default assay, they will be \emph{converted} with a
+warning
+\item if \code{assay_name} is not the default assay, they will be \emph{skipped} with a
+warning
+}
+
+To override this behavior, provide a custom mapping using the
+\code{obsp_mapping} argument.
+}
 }
 
 \examples{

--- a/man/as_Seurat.Rd
+++ b/man/as_Seurat.Rd
@@ -85,7 +85,7 @@ object
 }
 
 \subsection{Conversion table}{\tabular{llll}{
-   \strong{From \code{AnnData}} \tab \strong{To \code{Seurat}} \tab \strong{Example mapping argument} \tab \strong{Default if \code{NULL}} \cr
+   \strong{From \code{AnnData}} \tab \strong{To \code{Seurat}} \tab \strong{Example mapping argument} \tab \strong{Default} \cr
    \code{adata$X} \tab \code{Layers(seurat)} \tab \code{x_mapping = "counts"} \emph{OR} \code{layers_mapping = c(counts = NA)} \tab The data in \code{adata$X} is copied to a layer named \code{X} \cr
    \code{adata$layers} \tab \code{Layers(seurat)} \tab \code{layers_mapping = c(counts = "counts")} \tab All items are copied by name \cr
    \code{adata$obs} \tab \code{seurat[[]]} \tab \code{object_metadata_mapping = c(n_counts = "n_counts", cell_type = "CellType")} \tab All columns are copied by name \cr

--- a/man/as_SingleCellExperiment.Rd
+++ b/man/as_SingleCellExperiment.Rd
@@ -90,7 +90,7 @@ table
 }
 
 \subsection{Conversion table}{\tabular{llll}{
-   \strong{From \code{AnnData}} \tab \strong{To \code{SingleCellExperiment}} \tab \strong{Example mapping argument} \tab \strong{Default if \code{NULL}} \cr
+   \strong{From \code{AnnData}} \tab \strong{To \code{SingleCellExperiment}} \tab \strong{Example mapping argument} \tab \strong{Default} \cr
    \code{adata$X} \tab \code{assays(sce)} \tab \code{x_mapping = "counts"} \tab The data in \code{adata$X} is copied to the assay named \code{X} \cr
    \code{adata$layers} \tab \code{assays(sce)} \tab \code{assays_mapping = c(counts = "counts")} \tab All items are copied by name \cr
    \code{adata$obs} \tab \code{colData(sce)} \tab \code{colData_mapping = c(n_counts = "n_counts", cell_type = "CellType")} \tab All columns are copied by name \cr


### PR DESCRIPTION
**Related to:** Fixes #368 

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

- Handle conversion of graphs that don't have an associated assay
- Add a util functions to check dimensions of objects during conversion
- Check dimensions in `from_Seurat()` and skip if they don't match the `AnnData`
- Adjust documentation of default values in conversion man pages

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
