### PR TITLE
Force loading the environment in Python vignette

### DIFF
--- a/vignettes/usage_python.Rmd
+++ b/vignettes/usage_python.Rmd
@@ -12,6 +12,9 @@ vignette: >
 reticulate::py_require("mudata")
 reticulate::py_require("scanpy")
 
+# Force loading of the Python environment
+py_config <- reticulate::py_config()
+
 # Check if required Python packages are available
 python_available <- reticulate::py_module_available("scanpy") &&
   reticulate::py_module_available("mudata")


### PR DESCRIPTION
**Related to:** Fixes #386 
## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Add a `reticulate::py_config()` call to the Python usage vignette to force loading the Python environment

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
