### PR TITLE
Warn that matrix dim names won't be written to H5AD

### DIFF
--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -465,7 +465,11 @@ AbstractAnnData <- R6::R6Class(
     #   present but cannot be written for items in `collection`
     #
     # @return The validated named list
-    .validate_named_list = function(collection, label, warn_matrix_dimnames = FALSE) {
+    .validate_named_list = function(
+      collection,
+      label,
+      warn_matrix_dimnames = FALSE
+    ) {
       if (is.null(collection)) {
         return(collection)
       }

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -306,14 +306,23 @@ AbstractAnnData <- R6::R6Class(
   ),
   private = list(
     # @description `.validate_aligned_array()` checks that dimensions are
-    #   consistent with the anndata object.
+    #   consistent with the AnnData object.
     #
-    # @param mat A matrix to validate
-    # @param label Must be `"X"` or `"layer[[...]]"` where `...` is
-    #   the name of a layer.
-    # @param shape Expected dimensions of matrix
+    # @param mat A matrix (or data frame) to validate
+    # @param label Must be `"X"` or `"<<slot>>[[...]]"` where `<<slot>>` is the
+    #   name of an AnnData slot and `...` is an item in that slot
+    # @param shape Expected dimensions of `mat`, if shorter than `dim(mat)`,
+    #   only the first `length(shape)` dimensions are checked
     # @param expected_rownames Expected row names
     # @param expected_colnames Expected column names
+    # @param strip_rownames Whether to strip row names after validation
+    # @param strip_colnames Whether to strip column names after validation
+    # @param warn_rownames Whether to warn if row names are present but can not
+    #   be written
+    # @param warn_colnames Whether to warn if column names are present but can
+    #   not be written
+    #
+    # @return The validated matrix
     .validate_aligned_array = function(
       mat,
       label,
@@ -321,7 +330,9 @@ AbstractAnnData <- R6::R6Class(
       expected_rownames = NULL,
       expected_colnames = NULL,
       strip_rownames = TRUE,
-      strip_colnames = TRUE
+      strip_colnames = TRUE,
+      warn_rownames = FALSE,
+      warn_colnames = FALSE
     ) {
       if (is.null(mat)) {
         return(mat)
@@ -347,7 +358,7 @@ AbstractAnnData <- R6::R6Class(
         )
       }
 
-      if (!is.null(expected_rownames) & has_row_names(mat)) {
+      if (!is.null(expected_rownames) && has_row_names(mat)) {
         if (!identical(rownames(mat), expected_rownames)) {
           cli_abort(
             c(
@@ -364,6 +375,16 @@ AbstractAnnData <- R6::R6Class(
         rownames(mat) <- NULL
       }
 
+      if (warn_rownames && !is.data.frame(mat) && has_row_names(mat)) {
+        cli_warn(
+          c(
+            "Row names for {.field {label}} can not be written to {.obj_type_friendly {self}}",
+            "i" = "To write row names, store as a {.cls data.frame} instead of {.obj_type_friendly {mat}}"
+          ),
+          call = rlang::caller_env()
+        )
+      }
+
       if (!is.null(expected_colnames) & !is.null(colnames(mat))) {
         if (!identical(colnames(mat), expected_colnames)) {
           cli_abort(
@@ -376,9 +397,20 @@ AbstractAnnData <- R6::R6Class(
           )
         }
       }
+
       # Strip colnames for storage if requested
       if (strip_colnames) {
         colnames(mat) <- NULL
+      }
+
+      if (warn_colnames && !is.data.frame(mat) && !is.null(colnames(mat))) {
+        cli_warn(
+          c(
+            "Column names for {.field {label}} can not be written to {.obj_type_friendly {self}}",
+            "i" = "To write column names, store as a {.cls data.frame} instead of {.obj_type_friendly {mat}}"
+          ),
+          call = rlang::caller_env(4)
+        )
       }
 
       mat
@@ -389,9 +421,17 @@ AbstractAnnData <- R6::R6Class(
     # @param collection A named list of 0 or more matrix elements with
     #   whose entries will be validated
     # @param label The label of the collection, used for error messages
-    # @param shape Expected dimensions of arrays. Arrays may have more dimensions than specified here
+    # @param shape Expected dimensions of items in `collection`
     # @param expected_rownames Expected row names
     # @param expected_colnames Expected column names
+    # @param strip_rownames Whether to strip row names after validation
+    # @param strip_colnames Whether to strip column names after validation
+    # @param warn_rownames Whether to warn if row names are present but can not
+    #   be written
+    # @param warn_colnames Whether to warn if column names are present but can
+    #   not be written
+    #
+    # @return The validated mapping
     .validate_aligned_mapping = function(
       collection,
       label,
@@ -399,7 +439,9 @@ AbstractAnnData <- R6::R6Class(
       expected_rownames = NULL,
       expected_colnames = NULL,
       strip_rownames = TRUE,
-      strip_colnames = TRUE
+      strip_colnames = TRUE,
+      warn_rownames = FALSE,
+      warn_colnames = FALSE
     ) {
       if (is.null(collection)) {
         return(collection)
@@ -417,7 +459,9 @@ AbstractAnnData <- R6::R6Class(
           expected_rownames = expected_rownames,
           expected_colnames = expected_colnames,
           strip_rownames = strip_rownames,
-          strip_colnames = strip_colnames
+          strip_colnames = strip_colnames,
+          warn_rownames = warn_rownames,
+          warn_colnames = warn_colnames
         )
       }
 

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -375,16 +375,6 @@ AbstractAnnData <- R6::R6Class(
         rownames(mat) <- NULL
       }
 
-      if (warn_rownames && !is.data.frame(mat) && has_row_names(mat)) {
-        cli_warn(
-          c(
-            "Row names for {.field {label}} can not be written to {.obj_type_friendly {self}}",
-            "i" = "To write row names, store as a {.cls data.frame} instead of {.obj_type_friendly {mat}}"
-          ),
-          call = rlang::caller_env()
-        )
-      }
-
       if (!is.null(expected_colnames) & !is.null(colnames(mat))) {
         if (!identical(colnames(mat), expected_colnames)) {
           cli_abort(
@@ -403,15 +393,13 @@ AbstractAnnData <- R6::R6Class(
         colnames(mat) <- NULL
       }
 
-      if (warn_colnames && !is.data.frame(mat) && !is.null(colnames(mat))) {
-        cli_warn(
-          c(
-            "Column names for {.field {label}} can not be written to {.obj_type_friendly {self}}",
-            "i" = "To write column names, store as a {.cls data.frame} instead of {.obj_type_friendly {mat}}"
-          ),
-          call = rlang::caller_env(4)
-        )
-      }
+      warn_matrix_dimnames_not_writeable(
+        mat,
+        label,
+        to_object = self,
+        rows = warn_rownames,
+        cols = warn_colnames
+      )
 
       mat
     },

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -458,7 +458,14 @@ AbstractAnnData <- R6::R6Class(
 
     # @description `.validate_named_list()` checks for whether a value
     #   is NULL or a named list and throws an error if it is not.
-    .validate_named_list = function(collection, label) {
+    #
+    # @param collection A collection to validate
+    # @param label The label of the collection, used for error messages
+    # @param warn_matrix_dimnames Whether to warn if matrix dim names are
+    #   present but cannot be written for items in `collection`
+    #
+    # @return The validated named list
+    .validate_named_list = function(collection, label, warn_matrix_dimnames = FALSE) {
       if (is.null(collection)) {
         return(collection)
       }
@@ -472,6 +479,16 @@ AbstractAnnData <- R6::R6Class(
           "{.field {label}} must be a named {.cls list}, got {.cls {class(collection)}}",
           call = rlang::caller_env()
         )
+      }
+
+      if (warn_matrix_dimnames) {
+        purrr::walk2(collection, names(collection), \(.item, .item_name) {
+          warn_matrix_dimnames_not_writeable(
+            .item,
+            label = paste0(label, "[['", .item_name, "']]"),
+            to_object = self
+          )
+        })
       }
 
       collection

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -257,7 +257,11 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "uns")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_uns, status=done
-        private$.validate_named_list(value, "uns", warn_matrix_dimnames = TRUE) |>
+        private$.validate_named_list(
+          value,
+          "uns",
+          warn_matrix_dimnames = TRUE
+        ) |>
           write_h5ad_element(
             private$.h5obj,
             "uns",

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -106,7 +106,8 @@ HDF5AnnData <- R6::R6Class(
           c(self$n_obs()),
           expected_rownames = self$obs_names,
           strip_rownames = TRUE,
-          strip_colnames = FALSE
+          strip_colnames = FALSE,
+          warn_colnames = TRUE
         ) |>
           write_h5ad_element(
             private$.h5obj,
@@ -131,7 +132,8 @@ HDF5AnnData <- R6::R6Class(
           c(self$n_vars()),
           expected_rownames = self$var_names,
           strip_rownames = TRUE,
-          strip_colnames = FALSE
+          strip_colnames = FALSE,
+          warn_colnames = TRUE
         ) |>
           write_h5ad_element(
             private$.h5obj,

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -257,7 +257,7 @@ HDF5AnnData <- R6::R6Class(
         read_h5ad_element(private$.h5obj, "uns")
       } else {
         # trackstatus: class=HDF5AnnData, feature=set_uns, status=done
-        private$.validate_named_list(value, "uns") |>
+        private$.validate_named_list(value, "uns", warn_matrix_dimnames = TRUE) |>
           write_h5ad_element(
             private$.h5obj,
             "uns",

--- a/R/utils.R
+++ b/R/utils.R
@@ -210,7 +210,9 @@ check_dims_and_skip <- function(
 #' @param cols Whether to check column names
 #'
 #' @returns `NULL`, invisibly
+# nolint start: object_name_linter
 warn_matrix_dimnames_not_writeable <- function(mat, label, to_object, rows = TRUE, cols = TRUE) {
+  # nolint end: object_name_linter
   if (!is.matrix(mat) && !inherits(mat, "Matrix")) {
     return(invisible())
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -197,3 +197,57 @@ check_dims_and_skip <- function(
     x
   }
 }
+
+#' Warn matrix dim names not writeable
+#'
+#' Warn that matrix dim names can not be written to a given object
+#'
+#' @param mat The object to check, if not a matrix-like object nothing is
+#' checked
+#' @param label A label for `mat` to use in warning messages
+#' @param to_object The object to which `mat` would be written
+#' @param rows Whether to check row names
+#' @param cols Whether to check column names
+#'
+#' @returns `NULL`, invisibly
+warn_matrix_dimnames_not_writeable <- function(mat, label, to_object, rows = TRUE, cols = TRUE) {
+  if (!is.matrix(mat) && !inherits(mat, "Matrix")) {
+    return(invisible())
+  }
+
+  if (rows && !is.null(rownames(mat))) {
+    cli_warn(
+      c(
+        paste(
+          "Matrix row names cannot be written to {.obj_type_friendly {to_object}},",
+          "they will be lost"
+        ),
+        "i" = paste(
+          "To write row names for {.field {label}}, store it as",
+          "{.cls data.frame} instead of {.obj_type_friendly {mat}}"
+        ),
+        "i" = "{.strong NOTE:} {.field obs_names} and {.field var_names} are stored separately"
+      ),
+      call = NULL
+    )
+  }
+
+  if (cols && !is.null(colnames(mat))) {
+    cli_warn(
+      c(
+        paste(
+          "Matrix column names cannot be written to {.obj_type_friendly {to_object}},",
+          "they will be lost"
+        ),
+        "i" = paste(
+          "To write column names for {.field {label}}, store it as",
+          "{.cls data.frame} instead of {.obj_type_friendly {mat}}"
+        ),
+        "i" = "{.strong NOTE:} {.field obs_names} and {.field var_names} are stored separately"
+      ),
+      call = NULL
+    )
+  }
+
+  invisible()
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -211,7 +211,13 @@ check_dims_and_skip <- function(
 #'
 #' @returns `NULL`, invisibly
 # nolint start: object_name_linter
-warn_matrix_dimnames_not_writeable <- function(mat, label, to_object, rows = TRUE, cols = TRUE) {
+warn_matrix_dimnames_not_writeable <- function(
+  mat,
+  label,
+  to_object,
+  rows = TRUE,
+  cols = TRUE
+) {
   # nolint end: object_name_linter
   if (!is.matrix(mat) && !inherits(mat, "Matrix")) {
     return(invisible())

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -269,3 +269,50 @@ test_that("write_h5ad() gives consistent hashes", {
 
   expect_identical(hash1, hash2)
 })
+
+test_that("write_h5ad() warns about not writing matrix dim names", {
+  dummy <- generate_dataset(100, 200, example = TRUE, format = "AnnData")
+  file <- withr::local_file(tempfile(fileext = ".h5ad"))
+
+  dummy$obsm$test <- dummy$obsm$numeric_dense
+  colnames(dummy$obsm$test) <- paste0("Test", seq_len(ncol(dummy$obsm$test)))
+
+  expect_warning(
+    write_h5ad(dummy, file, mode = "w"),
+    "Matrix column names cannot be written"
+  )
+
+  dummy$obsm$test <- dummy$obsm$numeric_csparse
+  colnames(dummy$obsm$test) <- paste0("Test", seq_len(ncol(dummy$obsm$test)))
+
+  expect_warning(
+    write_h5ad(dummy, file, mode = "w"),
+    "Matrix column names cannot be written"
+  )
+
+  dummy$obsm$test <- NULL
+  dummy$varm$test <- dummy$varm$numeric_dense
+  colnames(dummy$varm$test) <- paste0("Test", seq_len(ncol(dummy$varm$test)))
+
+  expect_warning(
+    write_h5ad(dummy, file, mode = "w"),
+    "Matrix column names cannot be written"
+  )
+
+  dummy$varm$test <- dummy$varm$numeric_csparse
+  colnames(dummy$varm$test) <- paste0("Test", seq_len(ncol(dummy$varm$test)))
+
+  expect_warning(
+    write_h5ad(dummy, file, mode = "w"),
+    "Matrix column names cannot be written"
+  )
+
+  dummy$varm$test <- NULL
+  dummy$uns$test <- dummy$uns$mat_numeric_matrix
+  rownames(dummy$uns$test) <- paste0("Test", seq_len(nrow(dummy$uns$test)))
+  colnames(dummy$uns$test) <- paste0("Test", seq_len(ncol(dummy$uns$test)))
+
+  write_h5ad(dummy, file, mode = "w") |>
+    expect_warning("Matrix row names cannot be written") |>
+    expect_warning("Matrix column names cannot be written")
+})


### PR DESCRIPTION
**Related to:** Fixes #331 

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Add a warning that row/column names for matrices will not be written to a H5AD file (when they do not match `obs_names`/`var_names`).

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [x] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
