### PR TITLE
Bump GHA cache version to force reinstall

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,7 @@ jobs:
         with:
           extra-packages: any::lintr, any::styler, local::.
           needs: lint
+          cache-version: 2
 
       - name: Lint
         run: lintr::lint_package()

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -39,6 +39,7 @@ jobs:
         with:
           extra-packages: local::.
           needs: website
+          cache-version: 2
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)


### PR DESCRIPTION
**Related to:** https://github.com/scverse/anndataR/pull/190#issuecomment-3679016660

## Description

Force reinstall of Rhdf5lib / rhdf5 by creating a new package cache for the lint and pkgdown GitHub Action workflows. The same result can be achieved by manually deleting the existing caches rather than bumping the cache version.

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
