### PR TITLE
Warn that LEM is necessary when matrix with `rotation` attribute is provided 

### DIFF
--- a/R/from_SingleCellExperiment.R
+++ b/R/from_SingleCellExperiment.R
@@ -184,6 +184,13 @@ from_SingleCellExperiment <- function(
     reduction <- SingleCellExperiment::reducedDim(sce, reduction_name)
     if (inherits(reduction, "LinearEmbeddingMatrix")) {
       varm_mapping[reduction_name] <- reduction_name
+    } else if ("rotation" %in% names(attributes(reduction))) {
+      cli_warn(paste(
+        "Reduction {.val {reduction_name}} in SCE object has a {.attr rotation} attribute,",
+        "but is not a {.cls LinearEmbeddingMatrix}.",
+        "To include the {.attr rotation} information in {.code varm},",
+        "convert it to a {.cls LinearEmbeddingMatrix} first."
+      ))
     }
   }
 


### PR DESCRIPTION
**Related to:** <!-- Add links to related issues etc. here -->

## Description

Should we provide a util function to convert the default scater PCA?
e.g.:
```
pca_to_lem <- function(attr_mat) {
  LinearEmbeddingMatrix(
    sampleFactors = attr_mat,
    featureLoadings = attr(attr_mat, "rotation"),
    factorData = DataFrame(
      percentVar = attr(attr_mat, "percentVar"),
      varExplained = attr(attr_mat, "varExplained")
    )
  )
}
```

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
