### PR TITLE
Handle unnamed `SingleCellExperiment` assays in `as_AnnData()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Fix CI (PR #418).
 - Add continuous benchmarking using bencher (PR #423, PR #425).
+- Handle unnamed `SingleCellExperiment` assays in `as_AnnData()` by
+  automatically assigning names with a warning (PR #420).
 
 # anndataR 1.1.0
 

--- a/R/as_AnnData.R
+++ b/R/as_AnnData.R
@@ -82,6 +82,16 @@
 #'
 # nolint end: line_length_linter
 #'
+#'   ## Unnamed assays
+#'
+#'   If `assayNames(x)` is `NULL` or any assay names are empty they will
+#'   automatically be named with a warning:
+#'
+#'   **Examples:**
+#'
+#'   - Old names: `NULL` -> New names: `"assay1", "assay2", ...`
+#'   - Old names: `"counts"` -> New names: `"counts", "asssay2"`
+#'
 #' @section Converting from a `Seurat` object:
 #'
 #'   Only one assay can be converted from a [`SeuratObject::Seurat`] object to

--- a/R/as_AnnData.R
+++ b/R/as_AnnData.R
@@ -90,7 +90,7 @@
 #'   **Examples:**
 #'
 #'   - Old names: `NULL` -> New names: `"assay1", "assay2", ...`
-#'   - Old names: `"counts"` -> New names: `"counts", "asssay2"`
+#'   - Old names: `"counts"` -> New names: `"counts", "assay2"`
 #'
 #' @section Converting from a `Seurat` object:
 #'

--- a/R/from_SingleCellExperiment.R
+++ b/R/from_SingleCellExperiment.R
@@ -47,11 +47,14 @@ from_SingleCellExperiment <- function(
 
   assay_names <- SummarizedExperiment::assayNames(sce)
   if (
-        length(SummarizedExperiment::assays(sce)) > 0 &&
-          (is.null(assay_names) || any(assay_names == ""))
-      ) {
+    length(SummarizedExperiment::assays(sce)) > 0 &&
+      (is.null(assay_names) || any(assay_names == ""))
+  ) {
     if (is.null(assay_names)) {
-      assay_names <- paste0("assay", seq_along(SummarizedExperiment::assays(sce)))
+      assay_names <- paste0(
+        "assay",
+        seq_along(SummarizedExperiment::assays(sce))
+      )
     } else {
       empty_names <- which(assay_names == "")
       assay_names[empty_names] <- paste0("assay", empty_names)

--- a/R/from_SingleCellExperiment.R
+++ b/R/from_SingleCellExperiment.R
@@ -45,6 +45,29 @@ from_SingleCellExperiment <- function(
     )
   }
 
+  assay_names <- SummarizedExperiment::assayNames(sce)
+  if (
+        length(SummarizedExperiment::assays(sce)) > 0 &&
+          (is.null(assay_names) || any(assay_names == ""))
+      ) {
+    if (is.null(assay_names)) {
+      assay_names <- paste0("assay", seq_along(SummarizedExperiment::assays(sce)))
+    } else {
+      empty_names <- which(assay_names == "")
+      assay_names[empty_names] <- paste0("assay", empty_names)
+    }
+
+    cli_warn(c(
+      paste(
+        "Some {.field assays} in {.arg sce} are missing names.",
+        "They will automatically be named for conversion."
+      ),
+      "!" = "Old assay names: {style_vec(SummarizedExperiment::assayNames(sce))}",
+      "i" = "New assay names: {style_vec(assay_names)}"
+    ))
+    SummarizedExperiment::assayNames(sce) <- assay_names
+  }
+
   layers_mapping <- get_mapping(
     layers_mapping,
     .from_SCE_guess_layers,

--- a/R/ui.R
+++ b/R/ui.R
@@ -21,6 +21,10 @@ style_vec <- function(
 ) {
   trunc_style <- match.arg(trunc_style)
 
+  if (is.null(x)) {
+    return(cli::col_blue("NULL"))
+  }
+
   style <- list(
     "vec-last" = last,
     "vec-sep2" = last,

--- a/man/as_AnnData.Rd
+++ b/man/as_AnnData.Rd
@@ -160,7 +160,7 @@ automatically be named with a warning:
 \strong{Examples:}
 \itemize{
 \item Old names: \code{NULL} -> New names: \verb{"assay1", "assay2", ...}
-\item Old names: \code{"counts"} -> New names: \verb{"counts", "asssay2"}
+\item Old names: \code{"counts"} -> New names: \verb{"counts", "assay2"}
 }
 }
 }

--- a/man/as_AnnData.Rd
+++ b/man/as_AnnData.Rd
@@ -151,6 +151,18 @@ object.\tabular{llll}{
    \code{rowPairs(x)} \tab \code{adata$varp} \tab \code{varp_mapping = c(similarities = "gene_overlaps")} \tab All items are copied by name \cr
    \code{metadata(x)} \tab \code{adata$uns} \tab \code{uns_mapping = c(metadata = "project_metadata")} \tab All items are copied by name \cr
 }
+
+\subsection{Unnamed assays}{
+
+If \code{assayNames(x)} is \code{NULL} or any assay names are empty they will
+automatically be named with a warning:
+
+\strong{Examples:}
+\itemize{
+\item Old names: \code{NULL} -> New names: \verb{"assay1", "assay2", ...}
+\item Old names: \code{"counts"} -> New names: \verb{"counts", "asssay2"}
+}
+}
 }
 
 \section{Converting from a \code{Seurat} object}{

--- a/tests/testthat/test-from_SingleCellExperiment.R
+++ b/tests/testthat/test-from_SingleCellExperiment.R
@@ -289,7 +289,7 @@ for (var_key in names(var_mapping)) {
   })
 }
 
-test_that(paste0("as_AnnData (SCE) does not copy unmapped structs"), {
+test_that("as_AnnData (SCE) does not copy unmapped structs", {
   msg <- message_if_known(
     backend = "from_SCE",
     slot = c("obsm", "varm", "obsp", "varp", "uns"),
@@ -304,4 +304,16 @@ test_that(paste0("as_AnnData (SCE) does not copy unmapped structs"), {
   expect_true(is.null(ad_partial$obsp))
   expect_true(is.null(ad_partial$varp))
   expect_true(is.null(ad_partial$uns))
+})
+
+test_that("as_AnnData (SCE) handles unnamed assays", {
+  mat <- matrix(1:20, nrow = 5, ncol = 4)
+  sce <- SingleCellExperiment(assays = list(mat))
+
+  expect_warning(ad <- as_AnnData(sce), "missing names")
+  expect_identical(ad$layers_keys(), "assay1")
+
+  sce <- SingleCellExperiment(assays = list("mat" = mat, mat))
+  expect_warning(ad <- as_AnnData(sce), "missing names")
+  expect_identical(ad$layers_keys(), c("mat", "assay2"))
 })


### PR DESCRIPTION
**Related to:** Fixes #419 

## Description

- Add a check for unnamed assays in `from_SingleCellExpeiment()`
- Automatically name unnamed assays with a warning
- Add tests for unnamed assay in `as_AnnData()`
- Document automatics naming
- Handle `NULL` values in `style_vec()`   

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [x] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [ ] Bump devel version