### PR TITLE
Attempt at setting up bencher

### DIFF
--- a/.github/workflows/bench-base.yaml
+++ b/.github/workflows/bench-base.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           extra-packages: |
             any::bench
+            any::devtools
             any::jsonlite
             any::reticulate
 

--- a/.github/workflows/bench-base.yaml
+++ b/.github/workflows/bench-base.yaml
@@ -1,0 +1,75 @@
+# Track benchmark results for the base (devel) branch on bencher.dev
+on:
+  push:
+    branches:
+      - devel
+
+name: Benchmarks (base)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install hdf5-tools libsz2 libaec-dev
+
+      - name: Setup R and Bioconductor
+        uses: grimbough/bioc-actions/setup-bioc@v1
+        with:
+          bioc-version: devel
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::bench
+            any::jsonlite
+            any::reticulate
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install anndata dummy-anndata
+
+      - name: Configure reticulate
+        run: echo "RETICULATE_PYTHON=$(which python)" >> $GITHUB_ENV
+
+      - name: Install Bencher CLI
+        uses: bencherdev/bencher@v0.5.10
+
+      - name: Run benchmarks
+        run: Rscript benchmarks/run_benchmarks.R --output results.json
+
+      - name: Track benchmarks with Bencher
+        run: |
+          bencher run \
+            --project anndatar \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch devel \
+            --testbed ubuntu-latest \
+            --threshold-measure latency \
+            --threshold-test t_test \
+            --threshold-max-sample-size 64 \
+            --threshold-upper-boundary 0.99 \
+            --thresholds-reset \
+            --err \
+            --adapter json \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --file results.json

--- a/.github/workflows/bench-pr-run.yaml
+++ b/.github/workflows/bench-pr-run.yaml
@@ -1,0 +1,65 @@
+# Run benchmarks on pull requests (fork-safe: no secrets needed)
+# Results are uploaded as artifacts and tracked by bench-pr-track.yaml
+name: Benchmarks (PR run)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install hdf5-tools libsz2 libaec-dev
+
+      - name: Setup R and Bioconductor
+        uses: grimbough/bioc-actions/setup-bioc@v1
+        with:
+          bioc-version: devel
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::bench
+            any::jsonlite
+            any::reticulate
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: pip install anndata dummy-anndata
+
+      - name: Configure reticulate
+        run: echo "RETICULATE_PYTHON=$(which python)" >> $GITHUB_ENV
+
+      - name: Run benchmarks
+        run: Rscript benchmarks/run_benchmarks.R --output benchmark_results.json
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v6
+        with:
+          name: benchmark_results.json
+          path: ./benchmark_results.json
+
+      - name: Upload PR event
+        uses: actions/upload-artifact@v6
+        with:
+          name: event.json
+          path: ${{ github.event_path }}

--- a/.github/workflows/bench-pr-run.yaml
+++ b/.github/workflows/bench-pr-run.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           extra-packages: |
             any::bench
+            any::devtools
             any::jsonlite
             any::reticulate
 

--- a/.github/workflows/bench-pr-track.yaml
+++ b/.github/workflows/bench-pr-track.yaml
@@ -1,0 +1,64 @@
+# Track PR benchmark results on bencher.dev (runs after bench-pr-run completes)
+# This workflow runs in the context of the default branch, so secrets are available
+name: Benchmarks (PR track)
+
+on:
+  workflow_run:
+    workflows: ["Benchmarks (PR run)"]
+    types: [completed]
+
+jobs:
+  track:
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      checks: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    env:
+      BENCHMARK_RESULTS: benchmark_results.json
+      PR_EVENT: event.json
+    steps:
+      - name: Download benchmark results
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: ${{ env.BENCHMARK_RESULTS }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Download PR event
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: ${{ env.PR_EVENT }}
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - name: Export PR event data
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let fs = require('fs');
+            let prEvent = JSON.parse(fs.readFileSync(process.env.PR_EVENT, {encoding: 'utf8'}));
+            core.exportVariable("PR_HEAD", prEvent.pull_request.head.ref);
+            core.exportVariable("PR_HEAD_SHA", prEvent.pull_request.head.sha);
+            core.exportVariable("PR_BASE", prEvent.pull_request.base.ref);
+            core.exportVariable("PR_BASE_SHA", prEvent.pull_request.base.sha);
+            core.exportVariable("PR_NUMBER", prEvent.number);
+
+      - name: Install Bencher CLI
+        uses: bencherdev/bencher@v0.5.10
+
+      - name: Track PR benchmarks with Bencher
+        run: |
+          bencher run \
+            --project anndatar \
+            --token '${{ secrets.BENCHER_API_TOKEN }}' \
+            --branch "$PR_HEAD" \
+            --hash "$PR_HEAD_SHA" \
+            --start-point "$PR_BASE" \
+            --start-point-hash "$PR_BASE_SHA" \
+            --start-point-clone-thresholds \
+            --start-point-reset \
+            --testbed ubuntu-latest \
+            --err \
+            --adapter json \
+            --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+            --ci-number "$PR_NUMBER" \
+            --file "$BENCHMARK_RESULTS"

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,196 @@
+# anndataR Benchmarks
+
+Performance benchmarks for anndataR using [`bench::mark()`](https://bench.r-lib.org/) with continuous tracking on [bencher.dev](https://bencher.dev/perf/anndatar).
+
+## Prerequisites
+
+**R packages:**
+
+```r
+install.packages(c("bench", "jsonlite", "reticulate"))
+```
+
+**Python packages** (used to generate canonical test H5AD files via [dummy-anndata](https://pypi.org/project/dummy-anndata/)):
+
+```bash
+pip install anndata dummy-anndata
+```
+
+## Running locally
+
+From the repository root:
+
+```bash
+# Run all suites with default settings (2000 obs × 1000 vars, 3 iterations)
+Rscript benchmarks/run_benchmarks.R
+
+# Quick smoke test
+Rscript benchmarks/run_benchmarks.R --n-obs 100 --n-vars 50 --iterations 1
+
+# Run a single suite
+Rscript benchmarks/run_benchmarks.R --suite read
+
+# Custom output path
+Rscript benchmarks/run_benchmarks.R --output /tmp/results.json
+
+# Show all options
+Rscript benchmarks/run_benchmarks.R --help
+```
+
+### CLI options
+
+| Option           | Default                   | Description                                                             |
+| ---------------- | ------------------------- | ----------------------------------------------------------------------- |
+| `--n-obs N`      | 2000                      | Number of observations (cells)                                          |
+| `--n-vars N`     | 1000                      | Number of variables (genes)                                             |
+| `--iterations N` | 3                         | Iterations per benchmark                                                |
+| `--suite NAME`   | all                       | Suite to run: `all`, `read`, `write`, `get`, `set`, `convert`, `subset` |
+| `--output FILE`  | `benchmarks/results.json` | Output JSON path                                                        |
+
+## Output format
+
+Results are written as [Bencher Metric Format (BMF)](https://bencher.dev/docs/reference/bencher-metric-format/) JSON:
+
+```json
+{
+  "read_InMemory_float_csparse": {
+    "latency": {
+      "value": 266384594.08,
+      "lower_value": 254901470.03,
+      "upper_value": 266384594.08
+    },
+    "memory": {
+      "value": 1770408
+    }
+  }
+}
+```
+
+- **latency**: median / min / max in nanoseconds
+- **memory**: peak allocation in bytes
+
+## Benchmark suites
+
+### `read` — Reading H5AD files
+
+Benchmarks `read_h5ad()` across X matrix types and backends.
+
+| Benchmark                | Description                      |
+| ------------------------ | -------------------------------- |
+| `read_InMemory_{x_type}` | Read H5AD into `InMemoryAnnData` |
+| `read_HDF5_{x_type}`     | Read H5AD into `HDF5AnnData`     |
+
+X types: `float_matrix`, `float_csparse`, `float_rsparse`, `integer_csparse`
+
+### `write` — Writing H5AD files
+
+Benchmarks `write_h5ad()` from both backends with compression variants.
+
+| Benchmark                                | Description   |
+| ---------------------------------------- | ------------- |
+| `write_{backend}_{x_type}_{compression}` | Write to H5AD |
+
+Backends: `InMemory`, `HDF5`. Compressions: `none`, `gzip`.
+
+### `get` — Slot getters
+
+Benchmarks reading every AnnData slot, key methods, dimension methods, and S3 methods.
+
+| Benchmark                   | Description                                                                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_{backend}_{slot}`      | Access a slot (`X`, `obs`, `var`, `layers`, `obsm`, `varm`, `obsp`, `varp`, `uns`, `obs_names`, `var_names`)                                      |
+| `method_{backend}_{method}` | Call a method (`obs_keys`, `var_keys`, `obsm_keys`, `varm_keys`, `obsp_keys`, `varp_keys`, `layers_keys`, `uns_keys`, `n_obs`, `n_vars`, `shape`) |
+| `s3_{backend}_{method}`     | S3 generic (`dim`, `nrow`, `ncol`, `dimnames`, `rownames`, `colnames`)                                                                            |
+
+### `set` — Slot setters
+
+Benchmarks writing every AnnData slot on both backends.
+
+| Benchmark              | Description      |
+| ---------------------- | ---------------- |
+| `set_{backend}_{slot}` | Set a slot value |
+
+### `convert` — Format conversions
+
+| Benchmark                           | Description                 |
+| ----------------------------------- | --------------------------- |
+| `convert_HDF5_to_InMemory_{x_type}` | `as_InMemoryAnnData()`      |
+| `convert_InMemory_to_HDF5_{x_type}` | `as_HDF5AnnData()`          |
+| `convert_InMemory_to_SCE`           | `as_SingleCellExperiment()` |
+| `convert_SCE_to_InMemory`           | `as_AnnData()` from SCE     |
+| `convert_InMemory_to_Seurat`        | `as_Seurat()`               |
+| `convert_Seurat_to_InMemory`        | `as_AnnData()` from Seurat  |
+
+### `subset` — View creation and materialisation
+
+| Benchmark                           | Description                        |
+| ----------------------------------- | ---------------------------------- |
+| `subset_obs_int_{backend}`          | `ad[1:n, ]` integer index          |
+| `subset_both_int_{backend}`         | `ad[1:n, 1:p]` integer index       |
+| `subset_obs_char_{backend}`         | `ad[names, ]` character index      |
+| `subset_both_char_{backend}`        | `ad[names, names]` character index |
+| `subset_obs_logical_{backend}`      | `ad[logical, ]` logical index      |
+| `materialize_to_InMemory_{backend}` | `view$as_InMemoryAnnData()`        |
+| `materialize_to_HDF5_{backend}`     | `view$as_HDF5AnnData()`            |
+
+## Test data generation
+
+H5AD files are generated using Python's `dummy_anndata` package and written by Python `anndata`. This ensures the benchmark input files have canonical HDF5 encoding, independent of anndataR's own writer — so any encoding bugs in anndataR cannot silently affect benchmark data.
+
+Each file contains:
+
+- **X**: matrix of the specified type
+- **layers**: `float_csparse`, `integer_csparse`
+- **obs**: `categorical`, `dense_array`, `string_array`
+- **var**: `string_array`, `boolean_array`, `dense_array`
+- **obsm**: `float_matrix`, `float_csparse`
+- **varm**: `float_matrix`
+- **obsp / varp**: `float_csparse`
+- **uns**: `string`, `integer`, `float` (with nested dict)
+
+Generated files are cached in `$TMPDIR/anndatar_bench/` for the session.
+
+## CI integration
+
+Three GitHub Actions workflows handle continuous benchmarking:
+
+### `bench-base.yaml` — Baseline tracking
+
+- **Trigger**: push to `devel`
+- **Purpose**: Tracks baseline performance on [bencher.dev](https://bencher.dev/perf/anndatar)
+- Uses a t-test with upper boundary 0.99 to detect regressions
+
+### `bench-pr-run.yaml` — PR benchmark runner
+
+- **Trigger**: pull request (opened, reopened, synchronize)
+- **Purpose**: Runs benchmarks on PR code. Fork-safe — no secrets are needed.
+- Uploads `benchmark_results.json` and `event.json` as artifacts
+
+### `bench-pr-track.yaml` — PR result tracker
+
+- **Trigger**: `workflow_run` (after PR run completes)
+- **Purpose**: Downloads artifacts and submits results to bencher.dev. Runs in the default branch context so repository secrets are available.
+- Posts regression alerts as PR comments
+
+### Required secrets
+
+| Secret              | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `BENCHER_API_TOKEN` | API token from [bencher.dev](https://bencher.dev) |
+
+`GITHUB_TOKEN` is provided automatically.
+
+## File structure
+
+    benchmarks/
+    ├── README.md              # This file
+    ├── run_benchmarks.R       # Main entry point / CLI runner
+    ├── lib/
+    │   └── helpers.R          # Data generation, bench→BMF conversion, CLI parsing
+    └── suites/
+        ├── bench_read.R       # read_h5ad benchmarks
+        ├── bench_write.R      # write_h5ad benchmarks
+        ├── bench_get.R        # Slot getter benchmarks
+        ├── bench_set.R        # Slot setter benchmarks
+        ├── bench_convert.R    # Conversion benchmarks
+        └── bench_subset.R     # Subsetting / view benchmarks

--- a/benchmarks/lib/helpers.R
+++ b/benchmarks/lib/helpers.R
@@ -1,0 +1,241 @@
+# =============================================================================
+# Benchmark helpers: data generation, bench→BMF conversion, JSON output
+# =============================================================================
+
+# Load anndataR with internal functions available.
+# In development: devtools::load_all() exposes unexported functions.
+# In CI: the package is installed, so we use ::: for unexported functions.
+if (
+  file.exists("DESCRIPTION") &&
+    grepl("anndataR", readLines("DESCRIPTION", n = 1))
+) {
+  devtools::load_all(".", quiet = TRUE)
+} else {
+  library(anndataR)
+}
+library(Matrix)
+
+# ---------------------------------------------------------------------------
+# Python dependency check
+# ---------------------------------------------------------------------------
+
+#' Check that reticulate, anndata, and dummy_anndata are available
+check_bench_python_deps <- function() {
+  if (!requireNamespace("reticulate", quietly = TRUE)) {
+    stop(
+      "reticulate is required for benchmarks.\n",
+      "Install with: install.packages('reticulate')"
+    )
+  }
+  if (!reticulate::py_module_available("anndata")) {
+    stop(
+      "Python 'anndata' module is required for benchmarks.\n",
+      "Install with: reticulate::py_install('anndata')"
+    )
+  }
+  if (!reticulate::py_module_available("dummy_anndata")) {
+    stop(
+      "Python 'dummy_anndata' module is required for benchmarks.\n",
+      "Install with: reticulate::py_install('dummy-anndata')"
+    )
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Data generation (via Python dummy_anndata)
+# ---------------------------------------------------------------------------
+
+#' Generate and cache an H5AD file with all slots populated
+#'
+#' Uses Python's dummy_anndata to generate and write the H5AD file,
+#' ensuring canonical encoding independent of anndataR's own writer.
+#'
+#' @param x_type Matrix type for X (e.g. "float_csparse").
+#'   Must be a key in `dummy_anndata.matrix_generators`.
+#' @param n_obs Number of observations
+#' @param n_vars Number of variables
+#' @param cache_dir Directory to cache generated files
+#' @return Path to the generated H5AD file
+generate_bench_h5ad <- function(x_type, n_obs, n_vars, cache_dir) {
+  path <- file.path(cache_dir, paste0("bench_", x_type, ".h5ad"))
+  if (file.exists(path)) {
+    return(path)
+  }
+
+  da <- reticulate::import("dummy_anndata", convert = FALSE)
+
+  adata_py <- da$generate_dataset(
+    n_obs = as.integer(n_obs),
+    n_vars = as.integer(n_vars),
+    x_type = x_type,
+    layer_types = list("float_csparse", "integer_csparse"),
+    obs_types = list("categorical", "dense_array", "string_array"),
+    var_types = list("string_array", "boolean_array", "dense_array"),
+    obsm_types = list("float_matrix", "float_csparse"),
+    varm_types = list("float_matrix"),
+    obsp_types = list("float_csparse"),
+    varp_types = list("float_csparse"),
+    uns_types = list("string", "integer", "float"),
+    nested_uns_types = list("string", "float")
+  )
+
+  adata_py$write_h5ad(path)
+  path
+}
+
+# ---------------------------------------------------------------------------
+# bench::mark → BMF JSON conversion
+# ---------------------------------------------------------------------------
+
+#' Convert a bench::mark result into a BMF JSON entry
+#'
+#' @param bm A bench::mark result (tibble with one row)
+#' @param name Benchmark name
+#' @return A named list with BMF structure
+bench_to_bmf <- function(bm, name) {
+  # bench::mark returns bench_time objects; convert to nanoseconds
+  median_ns <- as.numeric(bm$median, units = "secs") * 1e9
+  min_ns <- as.numeric(bm$min, units = "secs") * 1e9
+  # max may not be available with iterations = 1
+  max_ns <- if ("max" %in% names(bm)) {
+    as.numeric(bm$max, units = "secs") * 1e9
+  } else {
+    median_ns
+  }
+
+  entry <- list(
+    latency = list(
+      value = median_ns,
+      lower_value = min_ns,
+      upper_value = max_ns
+    )
+  )
+
+  # Add memory allocation if available
+  mem_bytes <- as.numeric(bm$mem_alloc)
+  if (!is.na(mem_bytes)) {
+    entry[["memory"]] <- list(value = mem_bytes)
+  }
+
+  stats::setNames(list(entry), name)
+}
+
+#' Write accumulated BMF results to a JSON file
+#'
+#' @param results Named list of BMF entries (as returned by bench_to_bmf)
+#' @param path Output file path
+write_bmf_json <- function(results, path) {
+  # After accumulation via c(), results is already a flat named list:
+  # list("bench_name1" = list(latency = ..., memory = ...),
+  #      "bench_name2" = list(latency = ..., memory = ...), ...)
+  # Write it directly as BMF JSON.
+  jsonlite::write_json(results, path, auto_unbox = TRUE, pretty = TRUE)
+  invisible(path)
+}
+
+# ---------------------------------------------------------------------------
+# Safe benchmark runner
+# ---------------------------------------------------------------------------
+
+#' Run a single benchmark safely, returning a BMF entry or NULL on failure
+#'
+#' @param name Benchmark name
+#' @param expr Expression to benchmark (quoted)
+#' @param setup Expression to run before benchmarking (quoted)
+#' @param iterations Number of iterations
+#' @param env Environment for evaluation
+#' @return A BMF entry (list) or NULL if the benchmark failed
+run_one_benchmark <- function(
+  name,
+  expr,
+  setup = NULL,
+  iterations = 3L,
+  env = parent.frame()
+) {
+  tryCatch(
+    {
+      if (!is.null(setup)) {
+        eval(setup, envir = env)
+      }
+      bm <- bench::mark(
+        eval(expr, envir = env),
+        iterations = iterations,
+        check = FALSE,
+        filter_gc = FALSE
+      )
+      bench_to_bmf(bm, name)
+    },
+    error = function(e) {
+      message("  [SKIP] ", name, ": ", conditionMessage(e))
+      NULL
+    }
+  )
+}
+
+# ---------------------------------------------------------------------------
+# CLI helpers
+# ---------------------------------------------------------------------------
+
+#' Parse command-line arguments for the benchmark runner
+parse_bench_args <- function() {
+  args <- commandArgs(trailingOnly = TRUE)
+  opts <- list(
+    n_obs = 2000L,
+    n_vars = 1000L,
+    iterations = 3L,
+    suite = "all",
+    output = "benchmarks/results.json"
+  )
+
+  i <- 1L
+  while (i <= length(args)) {
+    switch(
+      args[i],
+      "--n-obs" = {
+        i <- i + 1L
+        opts$n_obs <- as.integer(args[i])
+      },
+      "--n-vars" = {
+        i <- i + 1L
+        opts$n_vars <- as.integer(args[i])
+      },
+      "--iterations" = ,
+      "-n" = {
+        i <- i + 1L
+        opts$iterations <- as.integer(args[i])
+      },
+      "--suite" = ,
+      "-s" = {
+        i <- i + 1L
+        opts$suite <- args[i]
+      },
+      "--output" = ,
+      "-o" = {
+        i <- i + 1L
+        opts$output <- args[i]
+      },
+      "--help" = ,
+      "-h" = {
+        cat(
+          "Usage: Rscript benchmarks/run_benchmarks.R [OPTIONS]\n",
+          "\n",
+          "Options:\n",
+          "  --n-obs N        Number of observations (default: 2000)\n",
+          "  --n-vars N       Number of variables (default: 1000)\n",
+          "  --iterations N   Iterations per benchmark (default: 3)\n",
+          "  --suite NAME     Suite to run: all, read, write, get, set,\n",
+          "                   convert, subset (default: all)\n",
+          "  --output FILE    Output JSON path (default: benchmarks/results.json)\n",
+          "  --help           Show this help\n",
+          sep = ""
+        )
+        quit(status = 0)
+      },
+      {
+        warning("Unknown argument: ", args[i])
+      }
+    )
+    i <- i + 1L
+  }
+  opts
+}

--- a/benchmarks/run_benchmarks.R
+++ b/benchmarks/run_benchmarks.R
@@ -1,0 +1,120 @@
+#!/usr/bin/env Rscript
+
+# =============================================================================
+# anndataR Benchmark Runner
+# =============================================================================
+# Runs bench::mark benchmarks and outputs Bencher Metric Format (BMF) JSON.
+#
+# Usage:
+#   Rscript benchmarks/run_benchmarks.R [OPTIONS]
+#
+# Options:
+#   --n-obs N        Number of observations (default: 2000)
+#   --n-vars N       Number of variables (default: 1000)
+#   --iterations N   Iterations per benchmark (default: 3)
+#   --suite NAME     Suite to run: all, read, write, get, set,
+#                    convert, subset (default: all)
+#   --output FILE    Output JSON path (default: benchmarks/results.json)
+#   --help           Show help
+# =============================================================================
+
+# Load helpers
+source("benchmarks/lib/helpers.R")
+
+# Load suite scripts
+source("benchmarks/suites/bench_read.R")
+source("benchmarks/suites/bench_write.R")
+source("benchmarks/suites/bench_get.R")
+source("benchmarks/suites/bench_set.R")
+source("benchmarks/suites/bench_convert.R")
+source("benchmarks/suites/bench_subset.R")
+
+# Parse CLI arguments
+opts <- parse_bench_args()
+
+cat("=== anndataR Benchmark Suite ===\n")
+cat(sprintf("  n_obs:       %d\n", opts$n_obs))
+cat(sprintf("  n_vars:      %d\n", opts$n_vars))
+cat(sprintf("  iterations:  %d\n", opts$iterations))
+cat(sprintf("  suite:       %s\n", opts$suite))
+cat(sprintf("  output:      %s\n", opts$output))
+cat("\n")
+
+# Check Python dependencies (dummy_anndata used for data generation)
+check_bench_python_deps()
+
+# ---------------------------------------------------------------------------
+# Generate / cache test H5AD files (written by Python anndata)
+# ---------------------------------------------------------------------------
+# x_types use dummy_anndata naming: float_*, integer_*
+x_types <- c(
+  "float_matrix",
+  "float_csparse",
+  "float_rsparse",
+  "integer_csparse"
+)
+
+cache_dir <- file.path(tempdir(), "anndatar_bench")
+dir.create(cache_dir, showWarnings = FALSE, recursive = TRUE)
+
+cat("Generating test data (via Python dummy_anndata)...\n")
+h5ad_paths <- setNames(
+  vapply(
+    x_types,
+    function(xt) {
+      cat(sprintf("  %s... ", xt))
+      path <- generate_bench_h5ad(xt, opts$n_obs, opts$n_vars, cache_dir)
+      cat("done\n")
+      path
+    },
+    character(1)
+  ),
+  x_types
+)
+cat("\n")
+
+# ---------------------------------------------------------------------------
+# Run selected suites
+# ---------------------------------------------------------------------------
+all_results <- list()
+suites_to_run <- if (opts$suite == "all") {
+  c("read", "write", "get", "set", "convert", "subset")
+} else {
+  opts$suite
+}
+
+for (suite in suites_to_run) {
+  cat(sprintf("Running suite: %s\n", suite))
+
+  suite_results <- switch(
+    suite,
+    read = bench_read(h5ad_paths, opts$iterations, x_types),
+    write = bench_write(h5ad_paths, opts$iterations, x_types),
+    get = bench_get(h5ad_paths, opts$iterations),
+    set = bench_set(h5ad_paths, opts$iterations),
+    convert = bench_convert(h5ad_paths, opts$iterations, x_types),
+    subset = bench_subset(h5ad_paths, opts$iterations),
+    {
+      warning("Unknown suite: ", suite)
+      list()
+    }
+  )
+
+  n_ok <- sum(!vapply(suite_results, is.null, logical(1)))
+  cat(sprintf("  %d benchmarks completed\n\n", n_ok))
+  all_results <- c(all_results, suite_results)
+}
+
+# ---------------------------------------------------------------------------
+# Write BMF JSON output
+# ---------------------------------------------------------------------------
+# Filter out NULLs
+all_results <- Filter(Negate(is.null), all_results)
+
+cat(sprintf("Total benchmarks: %d\n", length(all_results)))
+
+# Ensure output directory exists
+dir.create(dirname(opts$output), showWarnings = FALSE, recursive = TRUE)
+write_bmf_json(all_results, opts$output)
+
+cat(sprintf("Results written to: %s\n", opts$output))

--- a/benchmarks/suites/bench_convert.R
+++ b/benchmarks/suites/bench_convert.R
@@ -1,0 +1,121 @@
+# =============================================================================
+# Benchmark suite: conversions
+# =============================================================================
+# Benchmarks backend-to-backend conversions (HDF5↔InMemory) and
+# format conversions (InMemory↔SCE, InMemory↔Seurat).
+# =============================================================================
+
+bench_convert <- function(h5ad_paths, iterations, x_types) {
+  results <- list()
+
+  # --- Backend conversions (per X type) ---
+  for (xt in x_types) {
+    path <- h5ad_paths[[xt]]
+
+    # HDF5 → InMemory
+    env <- new.env(parent = globalenv())
+    env$.ad <- read_h5ad(path, as = "HDF5AnnData")
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("convert_HDF5_to_InMemory_", xt),
+        expr = quote(.ad$as_InMemoryAnnData()),
+        iterations = iterations,
+        env = env
+      )
+    )
+    env$.ad$close()
+
+    # InMemory → HDF5
+    env2 <- new.env(parent = globalenv())
+    env2$.ad <- read_h5ad(path, as = "InMemoryAnnData")
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("convert_InMemory_to_HDF5_", xt),
+        expr = quote({
+          .tmp <- tempfile(fileext = ".h5ad")
+          .result <- .ad$as_HDF5AnnData(.tmp)
+          .result$close()
+          unlink(.tmp)
+        }),
+        iterations = iterations,
+        env = env2
+      )
+    )
+  }
+
+  # --- Format conversions (using float_csparse as representative) ---
+  path <- h5ad_paths[["float_csparse"]]
+  ad <- read_h5ad(path, as = "InMemoryAnnData")
+
+  # InMemory → SingleCellExperiment
+  if (requireNamespace("SingleCellExperiment", quietly = TRUE)) {
+    env_sce <- new.env(parent = globalenv())
+    env_sce$.ad <- ad
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = "convert_InMemory_to_SCE",
+        expr = quote(as_SingleCellExperiment(.ad)),
+        iterations = iterations,
+        env = env_sce
+      )
+    )
+
+    # SCE → InMemory
+    sce <- as_SingleCellExperiment(ad)
+    env_sce2 <- new.env(parent = globalenv())
+    env_sce2$.sce <- sce
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = "convert_SCE_to_InMemory",
+        expr = quote(as_AnnData(.sce)),
+        iterations = iterations,
+        env = env_sce2
+      )
+    )
+  } else {
+    message("  [SKIP] SCE conversion: SingleCellExperiment not installed")
+  }
+
+  # InMemory → Seurat
+  if (requireNamespace("SeuratObject", quietly = TRUE)) {
+    env_seu <- new.env(parent = globalenv())
+    env_seu$.ad <- ad
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = "convert_InMemory_to_Seurat",
+        expr = quote(suppressWarnings(as_Seurat(.ad))),
+        iterations = iterations,
+        env = env_seu
+      )
+    )
+
+    # Seurat → InMemory
+    seurat <- suppressWarnings(as_Seurat(ad))
+    env_seu2 <- new.env(parent = globalenv())
+    env_seu2$.seurat <- seurat
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = "convert_Seurat_to_InMemory",
+        expr = quote(as_AnnData(.seurat)),
+        iterations = iterations,
+        env = env_seu2
+      )
+    )
+  } else {
+    message("  [SKIP] Seurat conversion: SeuratObject not installed")
+  }
+
+  results
+}

--- a/benchmarks/suites/bench_get.R
+++ b/benchmarks/suites/bench_get.R
@@ -1,0 +1,127 @@
+# =============================================================================
+# Benchmark suite: slot getters
+# =============================================================================
+# Benchmarks accessing every AnnData slot on both InMemory and HDF5 backends.
+# Also benchmarks all *_keys() methods, n_obs(), n_vars(), shape(), and
+# S3 methods (dim, nrow, ncol, dimnames, rownames, colnames).
+# =============================================================================
+
+.bench_slots <- c(
+  "X",
+  "obs",
+  "var",
+  "obs_names",
+  "var_names",
+  "layers",
+  "obsm",
+  "varm",
+  "obsp",
+  "varp",
+  "uns"
+)
+
+.bench_key_methods <- c(
+  "obs_keys",
+  "var_keys",
+  "layers_keys",
+  "obsm_keys",
+  "varm_keys",
+  "obsp_keys",
+  "varp_keys",
+  "uns_keys"
+)
+
+.bench_dim_methods <- c("n_obs", "n_vars", "shape")
+
+.bench_s3_methods <- list(
+  dim = quote(dim(.ad)),
+  nrow = quote(nrow(.ad)),
+  ncol = quote(ncol(.ad)),
+  dimnames = quote(dimnames(.ad)),
+  rownames = quote(rownames(.ad)),
+  colnames = quote(colnames(.ad))
+)
+
+bench_get <- function(h5ad_paths, iterations) {
+  results <- list()
+  path <- h5ad_paths[["float_csparse"]]
+
+  for (backend in c("InMemoryAnnData", "HDF5AnnData")) {
+    short <- if (backend == "InMemoryAnnData") "InMemory" else "HDF5"
+
+    # Open the AnnData
+    ad <- read_h5ad(path, as = backend)
+
+    # --- Slot getters ---
+    for (slot in .bench_slots) {
+      env <- new.env(parent = globalenv())
+      env$.ad <- ad
+      env$.slot <- slot
+
+      results <- c(
+        results,
+        run_one_benchmark(
+          name = paste0("get_", short, "_", slot),
+          expr = quote(.ad[[.slot]]),
+          iterations = iterations,
+          env = env
+        )
+      )
+    }
+
+    # --- *_keys() methods ---
+    for (method in .bench_key_methods) {
+      env <- new.env(parent = globalenv())
+      env$.ad <- ad
+
+      results <- c(
+        results,
+        run_one_benchmark(
+          name = paste0("method_", short, "_", method),
+          expr = bquote(.ad[[.(method)]]()),
+          iterations = iterations,
+          env = env
+        )
+      )
+    }
+
+    # --- n_obs, n_vars, shape ---
+    for (method in .bench_dim_methods) {
+      env <- new.env(parent = globalenv())
+      env$.ad <- ad
+
+      results <- c(
+        results,
+        run_one_benchmark(
+          name = paste0("method_", short, "_", method),
+          expr = bquote(.ad[[.(method)]]()),
+          iterations = iterations,
+          env = env
+        )
+      )
+    }
+
+    # --- S3 methods ---
+    for (s3name in names(.bench_s3_methods)) {
+      env <- new.env(parent = globalenv())
+      env$.ad <- ad
+
+      results <- c(
+        results,
+        run_one_benchmark(
+          name = paste0("s3_", short, "_", s3name),
+          expr = .bench_s3_methods[[s3name]],
+          iterations = iterations,
+          env = env
+        )
+      )
+    }
+
+    # Clean up HDF5 handle
+    if (backend == "HDF5AnnData") {
+      ad$close()
+    }
+  }
+
+  results
+}

--- a/benchmarks/suites/bench_read.R
+++ b/benchmarks/suites/bench_read.R
@@ -1,0 +1,41 @@
+# =============================================================================
+# Benchmark suite: read_h5ad
+# =============================================================================
+# Benchmarks reading H5AD files into InMemoryAnnData and HDF5AnnData
+# across different X matrix types.
+# =============================================================================
+
+bench_read <- function(h5ad_paths, iterations, x_types) {
+  results <- list()
+
+  for (xt in x_types) {
+    path <- h5ad_paths[[xt]]
+
+    # Read → InMemoryAnnData
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("read_InMemory_", xt),
+        expr = quote(read_h5ad(.path, as = "InMemoryAnnData")),
+        setup = bquote(.path <- .(path)),
+        iterations = iterations
+      )
+    )
+
+    # Read → HDF5AnnData
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("read_HDF5_", xt),
+        expr = quote({
+          ad <- read_h5ad(.path, as = "HDF5AnnData")
+          ad$close()
+        }),
+        setup = bquote(.path <- .(path)),
+        iterations = iterations
+      )
+    )
+  }
+
+  results
+}

--- a/benchmarks/suites/bench_set.R
+++ b/benchmarks/suites/bench_set.R
@@ -1,0 +1,64 @@
+# =============================================================================
+# Benchmark suite: slot setters
+# =============================================================================
+# Benchmarks setting every AnnData slot on both InMemory and HDF5 backends.
+# =============================================================================
+
+bench_set <- function(h5ad_paths, iterations) {
+  results <- list()
+  path <- h5ad_paths[["float_csparse"]]
+
+  slots <- c(
+    "X",
+    "obs",
+    "var",
+    "obs_names",
+    "var_names",
+    "layers",
+    "obsm",
+    "varm",
+    "obsp",
+    "varp",
+    "uns"
+  )
+
+  for (backend in c("InMemoryAnnData", "HDF5AnnData")) {
+    short <- if (backend == "InMemoryAnnData") "InMemory" else "HDF5"
+
+    for (slot in slots) {
+      # For HDF5, we need a fresh writable copy for each slot
+      if (backend == "HDF5AnnData") {
+        tmp <- tempfile(fileext = ".h5ad")
+        file.copy(path, tmp)
+        ad <- read_h5ad(tmp, as = "HDF5AnnData", mode = "r+")
+      } else {
+        ad <- read_h5ad(path, as = "InMemoryAnnData")
+      }
+
+      # Read the current value to use for setting
+      val <- ad[[slot]]
+
+      env <- new.env(parent = globalenv())
+      env$.ad <- ad
+      env$.val <- val
+      env$.slot <- slot
+
+      results <- c(
+        results,
+        run_one_benchmark(
+          name = paste0("set_", short, "_", slot),
+          expr = quote(.ad[[.slot]] <- .val),
+          iterations = iterations,
+          env = env
+        )
+      )
+
+      if (backend == "HDF5AnnData") {
+        ad$close()
+        unlink(tmp)
+      }
+    }
+  }
+
+  results
+}

--- a/benchmarks/suites/bench_subset.R
+++ b/benchmarks/suites/bench_subset.R
@@ -1,0 +1,133 @@
+# =============================================================================
+# Benchmark suite: subsetting & view materialization
+# =============================================================================
+# Benchmarks AnnDataView creation with different index types and
+# materialization back to concrete implementations.
+# =============================================================================
+
+bench_subset <- function(h5ad_paths, iterations) {
+  results <- list()
+  path <- h5ad_paths[["float_csparse"]]
+
+  for (backend in c("InMemoryAnnData", "HDF5AnnData")) {
+    short <- if (backend == "InMemoryAnnData") "InMemory" else "HDF5"
+    ad <- read_h5ad(path, as = backend)
+
+    n_obs <- ad$n_obs()
+    n_vars <- ad$n_vars()
+
+    # Pre-compute indices
+    obs_int <- sort(sample.int(n_obs, as.integer(n_obs * 0.5)))
+    var_int <- sort(sample.int(n_vars, as.integer(n_vars * 0.5)))
+    obs_char <- ad$obs_names[obs_int]
+    var_char <- ad$var_names[var_int]
+    obs_logical <- seq_len(n_obs) %in% obs_int
+
+    # --- View creation: integer indices ---
+    env <- new.env(parent = globalenv())
+    env$.ad <- ad
+    env$.obs_int <- obs_int
+    env$.var_int <- var_int
+
+    # Subset obs only
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("subset_obs_int_", short),
+        expr = quote(.ad[.obs_int, ]),
+        iterations = iterations,
+        env = env
+      )
+    )
+
+    # Subset both
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("subset_both_int_", short),
+        expr = quote(.ad[.obs_int, .var_int]),
+        iterations = iterations,
+        env = env
+      )
+    )
+
+    # --- View creation: character indices ---
+    env2 <- new.env(parent = globalenv())
+    env2$.ad <- ad
+    env2$.obs_char <- obs_char
+    env2$.var_char <- var_char
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("subset_obs_char_", short),
+        expr = quote(.ad[.obs_char, ]),
+        iterations = iterations,
+        env = env2
+      )
+    )
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("subset_both_char_", short),
+        expr = quote(.ad[.obs_char, .var_char]),
+        iterations = iterations,
+        env = env2
+      )
+    )
+
+    # --- View creation: logical indices ---
+    env3 <- new.env(parent = globalenv())
+    env3$.ad <- ad
+    env3$.obs_logical <- obs_logical
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("subset_obs_logical_", short),
+        expr = quote(.ad[.obs_logical, ]),
+        iterations = iterations,
+        env = env3
+      )
+    )
+
+    # --- Materialize view → InMemory ---
+    view <- ad[obs_int, var_int]
+    env4 <- new.env(parent = globalenv())
+    env4$.view <- view
+
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("materialize_to_InMemory_", short),
+        expr = quote(.view$as_InMemoryAnnData()),
+        iterations = iterations,
+        env = env4
+      )
+    )
+
+    # --- Materialize view → HDF5 ---
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("materialize_to_HDF5_", short),
+        expr = quote({
+          .tmp <- tempfile(fileext = ".h5ad")
+          .result <- .view$as_HDF5AnnData(.tmp)
+          .result$close()
+          unlink(.tmp)
+        }),
+        iterations = iterations,
+        env = env4
+      )
+    )
+
+    # Clean up
+    if (backend == "HDF5AnnData") {
+      ad$close()
+    }
+  }
+
+  results
+}

--- a/benchmarks/suites/bench_write.R
+++ b/benchmarks/suites/bench_write.R
@@ -1,0 +1,61 @@
+# =============================================================================
+# Benchmark suite: write_h5ad
+# =============================================================================
+# Benchmarks writing AnnData objects to H5AD files from both backends,
+# with different compression settings and X matrix types.
+# =============================================================================
+
+bench_write <- function(h5ad_paths, iterations, x_types) {
+  results <- list()
+
+  compressions <- c("none", "gzip")
+
+  for (xt in x_types) {
+    path <- h5ad_paths[[xt]]
+
+    for (compression in compressions) {
+      # Write from InMemoryAnnData
+      env <- new.env(parent = globalenv())
+      env$.ad <- read_h5ad(path, as = "InMemoryAnnData")
+      env$.compression <- compression
+
+      results <- c(
+        results,
+        run_one_benchmark(
+          name = paste0("write_InMemory_", xt, "_", compression),
+          expr = quote({
+            .tmp <- tempfile(fileext = ".h5ad")
+            .ad$write_h5ad(.tmp, compression = .compression)
+            unlink(.tmp)
+          }),
+          iterations = iterations,
+          env = env
+        )
+      )
+
+      # Write from HDF5AnnData
+      env2 <- new.env(parent = globalenv())
+      env2$.ad <- read_h5ad(path, as = "HDF5AnnData")
+      env2$.compression <- compression
+
+      results <- c(
+        results,
+        run_one_benchmark(
+          name = paste0("write_HDF5_", xt, "_", compression),
+          expr = quote({
+            .tmp <- tempfile(fileext = ".h5ad")
+            .ad$write_h5ad(.tmp, compression = .compression)
+            unlink(.tmp)
+          }),
+          iterations = iterations,
+          env = env2
+        )
+      )
+
+      # Close HDF5 handle
+      env2$.ad$close()
+    }
+  }
+
+  results
+}


### PR DESCRIPTION
**Related to:** <!-- Add links to related issues etc. here -->

## Description

This PR adds a continuous benchmarking infrastructure for anndataR using [Bencher](https://bencher.dev/perf/anndatar) and R's `bench::mark()`. It enables automated performance tracking on every push to `devel` and on every pull request, with regression alerts posted as PR comments.

### Benchmark suites (`benchmarks/suites/`)

Six benchmark suites covering the core anndataR operations:

| Suite | What it measures |
|-------|-----------------|
| **read** | `read_h5ad()` across X matrix types (`float_matrix`, `float_csparse`, `float_rsparse`, `integer_csparse`) and backends (`InMemoryAnnData`, `HDF5AnnData`) |
| **write** | `write_h5ad()` from both backends with `none` and `gzip` compression |
| **get** | Slot getters (`X`, `obs`, `var`, `layers`, `obsm`, `varm`, `obsp`, `varp`, `uns`, `obs_names`, `var_names`), key methods, dimension methods, and S3 methods |
| **set** | Slot setters on both backends |
| **convert** | Format conversions: `InMemory` ↔ `HDF5`, `InMemory` ↔ `SingleCellExperiment`, `InMemory` ↔ `Seurat` |
| **subset** | View creation (integer, character, logical indexing) and materialisation to `InMemoryAnnData` / `HDF5AnnData` |

### Runner (`benchmarks/run_benchmarks.R`)

CLI-driven entry point with configurable options:

```bash
# Run all suites (default: 2000 obs × 1000 vars, 3 iterations)
Rscript benchmarks/run_benchmarks.R

# Quick smoke test
Rscript benchmarks/run_benchmarks.R --n-obs 100 --n-vars 50 --iterations 1

# Run a single suite
Rscript benchmarks/run_benchmarks.R --suite read
```

Outputs results in [Bencher Metric Format (BMF)](https://bencher.dev/docs/reference/bencher-metric-format/) JSON with latency (nanoseconds) and memory (bytes) metrics.

### Test data generation (`benchmarks/lib/helpers.R`)

H5AD test files are generated using Python's `dummy_anndata` package and written by Python `anndata`, ensuring benchmark inputs have canonical HDF5 encoding independent of anndataR's own writer.

### CI workflows (`.github/workflows/`)

Three GitHub Actions workflows:

| Workflow | Trigger | Purpose |
|----------|---------|---------|
| `bench-base.yaml` | Push to `devel` | Track baseline performance on bencher.dev using t-test with upper boundary 0.99 |
| `bench-pr-run.yaml` | Pull request | Run benchmarks on PR code (fork-safe, no secrets needed); upload results as artifacts |
| `bench-pr-track.yaml` | After PR run completes | Download artifacts and submit to bencher.dev; post regression alerts as PR comments |

### Required secrets

| Secret | Description |
|--------|-------------|
| `BENCHER_API_TOKEN` | API token from [bencher.dev](https://bencher.dev) |

`GITHUB_TOKEN` is provided automatically.


## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [ ] Bump devel version
