### PR TITLE
Improve performance by auto-chunking HDF5 writes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: anndataR
 Title: AnnData interoperability in R
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
     person("Robrecht", "Cannoodt", , "rcannood@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,12 @@
-# anndataR 1.1.0
+# anndataR 1.1.1
 
-- Bioconductor 3.23 devel
 - Fix CI (PR #418).
 - Add continuous benchmarking using bencher (PR #423).
 - Add auto-chunking for HDF5 writes to improve performance (PR #424).
+
+# anndataR 1.1.0
+
+- Bioconductor 3.23 devel
 
 # anndataR 1.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 - Bioconductor 3.23 devel
 - Fix CI (PR #418).
 - Add continuous benchmarking using bencher (PR #423).
-- Add auto-chunking for HDF5 writes to improve performance (PR #xxx).
+- Add auto-chunking for HDF5 writes to improve performance (PR #424).
 
 # anndataR 1.0.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Fix CI (PR #418).
 - Add continuous benchmarking using bencher (PR #423, PR #425).
+- Allow manually setting chunk size for HDF5 writes (PR #424).
 - Add auto-chunking for HDF5 writes to improve performance (PR #424).
 
 # anndataR 1.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Bioconductor 3.23 devel
 - Fix CI (PR #418).
+- Add continuous benchmarking using bencher (PR #423).
+- Add auto-chunking for HDF5 writes to improve performance (PR #xxx).
 
 # anndataR 1.0.1
 

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -271,18 +271,21 @@ AbstractAnnData <- R6::R6Class(
     #'
     #' @param file See [as_HDF5AnnData()]
     #' @param compression See [as_HDF5AnnData()]
+    #' @param chunk_size See [as_HDF5AnnData()]
     #' @param mode See [as_HDF5AnnData()]
     #'
     #' @return An [`HDF5AnnData`] object
     as_HDF5AnnData = function(
       file,
       compression = c("none", "gzip", "lzf"),
+      chunk_size = "auto",
       mode = c("w-", "r", "r+", "a", "w", "x")
     ) {
       as_HDF5AnnData(
         adata = self,
         file = file,
         compression = compression,
+        chunk_size = chunk_size,
         mode = mode
       )
     },
@@ -293,15 +296,23 @@ AbstractAnnData <- R6::R6Class(
     #'
     #' @param path See [write_h5ad()]
     #' @param compression See [write_h5ad()]
+    #' @param chunk_size See [write_h5ad()]
     #' @param mode See [write_h5ad()]
     #'
     #' @return `path` invisibly
     write_h5ad = function(
       path,
       compression = c("none", "gzip", "lzf"),
+      chunk_size = "auto",
       mode = c("w-", "r", "r+", "a", "w", "x")
     ) {
-      write_h5ad(object = self, path, compression = compression, mode = mode)
+      write_h5ad(
+        object = self,
+        path,
+        compression = compression,
+        chunk_size = chunk_size,
+        mode = mode
+      )
     }
   ),
   private = list(

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -22,6 +22,7 @@ HDF5AnnData <- R6::R6Class(
     .h5obj = NULL,
     .close_on_finalize = FALSE,
     .compression = NULL,
+    .chunk_size = "auto",
 
     .check_file_valid = function() {
       if (!rhdf5::H5Iis_valid(private$.h5obj)) {
@@ -62,7 +63,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "X",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -86,7 +88,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "layers",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -112,7 +115,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "obsm",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -138,7 +142,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "varm",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -162,7 +167,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "obsp",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -186,7 +192,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "varp",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -203,7 +210,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "obs",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -220,7 +228,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "var",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     },
@@ -237,7 +246,8 @@ HDF5AnnData <- R6::R6Class(
           value,
           private$.h5obj,
           "obs",
-          private$.compression
+          private$.compression,
+          chunk_size = private$.chunk_size
         )
       }
     },
@@ -254,7 +264,8 @@ HDF5AnnData <- R6::R6Class(
           value,
           private$.h5obj,
           "var",
-          private$.compression
+          private$.compression,
+          chunk_size = private$.chunk_size
         )
       }
     },
@@ -275,7 +286,8 @@ HDF5AnnData <- R6::R6Class(
           write_h5ad_element(
             private$.h5obj,
             "uns",
-            private$.compression
+            private$.compression,
+            chunk_size = private$.chunk_size
           )
       }
     }
@@ -301,6 +313,8 @@ HDF5AnnData <- R6::R6Class(
     #'   details
     #' @param compression The compression algorithm to use. See
     #'   [as_HDF5AnnData()] for details
+    #' @param chunk_size The target chunk size in bytes. See
+    #'   [as_HDF5AnnData()] for details
     #'
     #' @details
     #' The constructor creates a new HDF5 `AnnData` interface object. This can
@@ -320,7 +334,8 @@ HDF5AnnData <- R6::R6Class(
       uns = NULL,
       shape = NULL,
       mode = c("a", "r", "r+", "w", "w-", "x"),
-      compression = c("none", "gzip", "lzf")
+      compression = c("none", "gzip", "lzf"),
+      chunk_size = "auto"
     ) {
       check_requires("HDF5AnnData", "rhdf5", where = "Bioc")
 
@@ -328,6 +343,7 @@ HDF5AnnData <- R6::R6Class(
       mode <- match.arg(mode)
 
       private$.compression <- compression
+      private$.chunk_size <- chunk_size
 
       private$.close_on_finalize <- is.character(file)
 
@@ -404,7 +420,7 @@ HDF5AnnData <- R6::R6Class(
           shape <- get_shape(obs, var, X, shape)
           obs <- get_initial_obs(obs, X, shape)
           var <- get_initial_var(var, X, shape)
-          write_empty_h5ad(file, obs, var, compression)
+          write_empty_h5ad(file, obs, var, compression, chunk_size)
         }
       }
 
@@ -516,6 +532,11 @@ HDF5AnnData <- R6::R6Class(
 #' @param compression The compression algorithm to use when writing the
 #'   HDF5 file. Can be one of `"none"`, `"gzip"` or `"lzf"`. Defaults to
 #'   `"none"`.
+#' @param chunk_size The target chunk size in bytes to use when writing
+#'   HDF5 datasets. When `"auto"` (default), the chunk size is determined
+#'   automatically using an algorithm that mimics h5py's auto-chunking
+#'   behaviour. Set to `NULL` to disable chunking (contiguous storage,
+#'   the rhdf5 default), or a number to use a specific target size in bytes.
 #' @param mode The mode to open the HDF5 file:
 #'
 #'   * `a` creates a new file or opens an existing one for read/write
@@ -536,6 +557,7 @@ as_HDF5AnnData <- function(
   adata,
   file,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   mode = c("w-", "r", "r+", "a", "w", "x")
 ) {
   if (!(inherits(adata, "AbstractAnnData"))) {
@@ -558,7 +580,8 @@ as_HDF5AnnData <- function(
     uns = adata$uns,
     shape = adata$shape(),
     mode = mode,
-    compression = compression
+    compression = compression,
+    chunk_size = chunk_size
   )
 }
 

--- a/R/write_h5ad.R
+++ b/R/write_h5ad.R
@@ -8,6 +8,12 @@
 #' @param path Path of the file to write to
 #' @param compression The compression algorithm to use when writing the HDF5
 #'   file. Can be one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
+#' @param chunk_size The target chunk size in bytes to use when writing HDF5
+#'   datasets. When `"auto"` (default), the chunk size is determined
+#'   automatically using an algorithm that mimics h5py's auto-chunking
+#'   behaviour. Set to `NULL` to disable chunking (contiguous storage,
+#'   the rhdf5 default), or a number to use a specific target size in bytes.
+#'   This only affects array-like datasets; scalar values are unaffected.
 #' @param mode The mode to open the HDF5 file.
 #'
 #'   * `a` creates a new file or opens an existing one for read/write
@@ -94,6 +100,7 @@ write_h5ad <- function(
   object,
   path,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   mode = c("w-", "r", "r+", "a", "w", "x"),
   ...
 ) {
@@ -102,6 +109,7 @@ write_h5ad <- function(
     object$as_HDF5AnnData(
       path,
       compression = compression,
+      chunk_size = chunk_size,
       mode = mode
     )
   } else {
@@ -110,6 +118,7 @@ write_h5ad <- function(
       output_class = "HDF5AnnData",
       file = path,
       compression = compression,
+      chunk_size = chunk_size,
       mode = mode,
       ...
     )

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -26,6 +26,7 @@ write_h5ad_element <- function(
   file,
   name,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   stop_on_error = FALSE,
   ...
 ) {
@@ -97,6 +98,7 @@ write_h5ad_element <- function(
         file = file,
         name = name,
         compression = compression,
+        chunk_size = chunk_size,
         ...
       )
     },
@@ -159,7 +161,14 @@ write_h5ad_encoding <- function(file, name, encoding, version) {
 #' @param version Encoding version of the element to write
 #'
 #' @noRd
-write_h5ad_null <- function(value, file, name, compression, version = "0.1.0") {
+write_h5ad_null <- function(
+  value,
+  file,
+  name,
+  compression,
+  chunk_size = "auto",
+  version = "0.1.0"
+) {
   if (isFALSE(getOption("anndataR.write_null", "TRUE"))) {
     return(invisible(NULL))
   }
@@ -195,6 +204,7 @@ write_h5ad_dense_array <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.2.0"
 ) {
   version <- match.arg(version)
@@ -230,7 +240,8 @@ write_h5ad_dense_array <- function(
       file = file,
       name = name,
       value = value,
-      compression = compression
+      compression = compression,
+      chunk_size = chunk_size
     )
   } else {
     hdf5_write_dataset(
@@ -238,7 +249,8 @@ write_h5ad_dense_array <- function(
       name = name,
       value = value,
       H5type = H5type,
-      compression = compression
+      compression = compression,
+      chunk_size = chunk_size
     )
   }
 
@@ -262,6 +274,7 @@ write_h5ad_sparse_array <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.1.0"
 ) {
   version <- match.arg(version)
@@ -292,19 +305,22 @@ write_h5ad_sparse_array <- function(
     file = file,
     name = paste0(name, "/indices"),
     value = attr(value, indices_attr),
-    compression = compression
+    compression = compression,
+    chunk_size = chunk_size
   )
   hdf5_write_dataset(
     file = file,
     name = paste0(name, "/indptr"),
     value = value@p,
-    compression = compression
+    compression = compression,
+    chunk_size = chunk_size
   )
   hdf5_write_dataset(
     file = file,
     name = paste0(name, "/data"),
     value = value@x,
-    compression = compression
+    compression = compression,
+    chunk_size = chunk_size
   )
   write_h5ad_encoding(file, name, type, version)
 
@@ -336,6 +352,7 @@ write_h5ad_nullable_boolean <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.1.0"
 ) {
   # nolint end: object_length_linter
@@ -348,14 +365,16 @@ write_h5ad_nullable_boolean <- function(
     value_no_na,
     file,
     paste0(name, "/values"),
-    compression
+    compression,
+    chunk_size
   )
 
   write_h5ad_dense_array(
     is.na(value),
     file,
     paste0(name, "/mask"),
-    compression
+    compression,
+    chunk_size
   )
 
   # set encoding
@@ -380,6 +399,7 @@ write_h5ad_nullable_integer <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.1.0"
 ) {
   # nolint end: object_length_linter
@@ -392,14 +412,16 @@ write_h5ad_nullable_integer <- function(
     value_no_na,
     file,
     paste0(name, "/values"),
-    compression
+    compression,
+    chunk_size
   )
 
   write_h5ad_dense_array(
     is.na(value),
     file,
     paste0(name, "/mask"),
-    compression
+    compression,
+    chunk_size
   )
 
   write_h5ad_encoding(file, name, "nullable-integer", version)
@@ -422,6 +444,7 @@ write_h5ad_string_array <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.2.0"
 ) {
   if (!is.vector(value)) {
@@ -436,7 +459,8 @@ write_h5ad_string_array <- function(
     file = file,
     name = name,
     value = value,
-    compression = compression
+    compression = compression,
+    chunk_size = chunk_size
   )
 
   write_h5ad_encoding(file, name, "string-array", version)
@@ -459,6 +483,7 @@ write_h5ad_categorical <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.2.0"
 ) {
   rhdf5::h5createGroup(file, name)
@@ -476,9 +501,16 @@ write_h5ad_categorical <- function(
     categories,
     file,
     paste0(name, "/categories"),
-    compression
+    compression,
+    chunk_size
   )
-  write_h5ad_dense_array(codes, file, paste0(name, "/codes"), compression)
+  write_h5ad_dense_array(
+    codes,
+    file,
+    paste0(name, "/codes"),
+    compression,
+    chunk_size
+  )
 
   # Write encoding
   write_h5ad_encoding(
@@ -515,6 +547,7 @@ write_h5ad_string_scalar <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.2.0"
 ) {
   hdf5_write_scalar(
@@ -544,6 +577,7 @@ write_h5ad_numeric_scalar <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.2.0"
 ) {
   if (is.logical(value)) {
@@ -552,7 +586,8 @@ write_h5ad_numeric_scalar <- function(
       name = name,
       value = value,
       is_scalar = TRUE,
-      compression = compression
+      compression = compression,
+      chunk_size = chunk_size
     )
   } else {
     hdf5_write_scalar(
@@ -583,6 +618,7 @@ write_h5ad_mapping <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.1.0"
 ) {
   rhdf5::h5createGroup(file, name)
@@ -593,7 +629,8 @@ write_h5ad_mapping <- function(
       value[[key]],
       file,
       paste0(name, "/", key),
-      compression
+      compression,
+      chunk_size = chunk_size
     )
   }
 
@@ -620,6 +657,7 @@ write_h5ad_data_frame <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   index = NULL,
   version = "0.2.0"
 ) {
@@ -652,7 +690,8 @@ write_h5ad_data_frame <- function(
       value[[col]],
       file,
       paste0(name, "/", col),
-      compression
+      compression,
+      chunk_size = chunk_size
     )
   }
 
@@ -670,7 +709,8 @@ write_h5ad_data_frame <- function(
     index_value,
     file,
     name,
-    compression
+    compression,
+    chunk_size = chunk_size
   )
 
   col_order <- colnames(value)
@@ -708,6 +748,7 @@ write_h5ad_data_frame_index <- function(
   file,
   name,
   compression,
+  chunk_size = "auto",
   version = "0.2.0"
 ) {
   attrs <- rhdf5::h5readAttributes(file, name, native = FALSE)
@@ -717,7 +758,8 @@ write_h5ad_data_frame_index <- function(
     index_value,
     file,
     paste0(name, "/", index_name),
-    compression
+    compression,
+    chunk_size = chunk_size
   )
 }
 
@@ -738,12 +780,25 @@ write_empty_h5ad <- function(
   obs,
   var,
   compression,
+  chunk_size = "auto",
   version = "0.1.0"
 ) {
   write_h5ad_encoding(file, "/", "anndata", "0.1.0")
 
-  write_h5ad_element(obs[, integer(0)], file, "/obs", compression)
-  write_h5ad_element(var[, integer(0)], file, "/var", compression)
+  write_h5ad_element(
+    obs[, integer(0)],
+    file,
+    "/obs",
+    compression,
+    chunk_size = chunk_size
+  )
+  write_h5ad_element(
+    var[, integer(0)],
+    file,
+    "/var",
+    compression,
+    chunk_size = chunk_size
+  )
 
   rhdf5::h5createGroup(file, "layers")
   write_h5ad_encoding(file, "/layers", "dict", "0.1.0")

--- a/R/write_hdf5_helpers.R
+++ b/R/write_hdf5_helpers.R
@@ -8,6 +8,10 @@
 #' @param H5type Datatype to write, see [rhdf5::h5createDataset()]
 #' @param compression The compression to use when writing the element. Can be
 #'   one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
+#' @param chunk_size Target chunk size in bytes. When `"auto"` (default), the
+#'   chunk size is determined automatically using `hdf5_auto_chunk()`.
+#'   When `NULL`, chunking is disabled (contiguous storage, the rhdf5 default).
+#'   When a number, it is used as the target chunk size in bytes.
 #' @param ... Other arguments passed to [rhdf5::h5write()]
 #'
 #' @noRd
@@ -17,6 +21,7 @@ hdf5_write_dataset <- function(
   value,
   H5type = NULL,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   ...
 ) {
   compression <- match.arg(compression)
@@ -33,12 +38,25 @@ hdf5_write_dataset <- function(
     compression <- "none"
   }
 
-  # Compute chunk sizes by mimicking h5py's auto-chunking algorithm
-  chunk <- hdf5_auto_chunk(dims, storage.mode(value))
+  # Compute chunk sizes
+  # - "auto"   → mimic h5py's auto-chunking algorithm
+  # - NULL     → no chunking (contiguous storage, rhdf5 default)
+  # - <number> → use provided byte size as target
+  if (identical(chunk_size, "auto")) {
+    chunk <- hdf5_auto_chunk(dims, storage.mode(value), target_size = NULL)
+  } else if (is.null(chunk_size)) {
+    chunk <- NULL
+  } else {
+    chunk <- hdf5_auto_chunk(
+      dims,
+      storage.mode(value),
+      target_size = chunk_size
+    )
+  }
 
-  # When no compression is used, set level = 0 to prevent rhdf5 from warning
-  # about "Compression (level > 0) requires chunking" when chunk is NULL
-  level <- if (compression == "none") 0L else 6L
+  # When no chunking or no compression, set level = 0 to prevent rhdf5 from
+  # warning about "Compression (level > 0) requires chunking"
+  level <- if (is.null(chunk) || compression == "none") 0L else 6L
 
   rhdf5::h5createDataset(
     file,
@@ -133,7 +151,8 @@ hdf5_write_boolean_dataset <- function(
   name,
   value,
   is_scalar = FALSE,
-  compression = c("none", "gzip", "lzf")
+  compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto"
 ) {
   # Based on https://stackoverflow.com/a/74653515/4384120
 
@@ -299,11 +318,13 @@ hdf5_clear_rhdf5_attributes <- function(h5file, name) {
 #'
 #' @param dims Integer vector of dataset dimensions
 #' @param storage_mode Storage mode of the data ("double", "integer", etc.)
+#' @param target_size The target chunk size in bytes. When `NULL` (default),
+#'   the target size is determined automatically based on the dataset size.
 #'
 #' @return Integer vector of chunk dimensions
 #'
 #' @noRd
-hdf5_auto_chunk <- function(dims, storage_mode) {
+hdf5_auto_chunk <- function(dims, storage_mode, target_size = NULL) {
   # h5py constants
   chunk_base <- 16L * 1024L # 16 KB - multiplier for target calculation
   chunk_min <- 8L * 1024L # 8 KB - soft lower limit
@@ -322,9 +343,11 @@ hdf5_auto_chunk <- function(dims, storage_mode) {
   chunk <- as.double(dims)
 
   # Compute dynamic target size using h5py's PyTables-derived expression
-  dset_size <- prod(chunk) * element_bytes
-  target_size <- chunk_base * (2^log10(dset_size / (1024 * 1024)))
-  target_size <- max(chunk_min, min(chunk_max, target_size))
+  if (is.null(target_size)) {
+    dset_size <- prod(chunk) * element_bytes
+    target_size <- chunk_base * (2^log10(dset_size / (1024 * 1024)))
+    target_size <- max(chunk_min, min(chunk_max, target_size))
+  }
 
   # Round-robin halving of dimensions until within target
   idx <- 0L

--- a/R/write_hdf5_helpers.R
+++ b/R/write_hdf5_helpers.R
@@ -33,12 +33,21 @@ hdf5_write_dataset <- function(
     compression <- "none"
   }
 
+  # Compute chunk sizes by mimicking h5py's auto-chunking algorithm
+  chunk <- hdf5_auto_chunk(dims, storage.mode(value))
+
+  # When no compression is used, set level = 0 to prevent rhdf5 from warning
+  # about "Compression (level > 0) requires chunking" when chunk is NULL
+  level <- if (compression == "none") 0L else 6L
+
   rhdf5::h5createDataset(
     file,
     name,
     dims,
     storage.mode = storage.mode(value),
     H5type = H5type,
+    chunk = chunk,
+    level = level,
     filter = toupper(compression),
     native = FALSE
   )
@@ -277,4 +286,71 @@ hdf5_clear_rhdf5_attributes <- function(h5file, name) {
       hdf5_clear_rhdf5_attributes(h5file, paste0(name, "/", item))
     }
   }
+}
+
+#' Compute chunk dimensions for an HDF5 dataset
+#'
+#' Attempt to match h5py's auto-chunking algorithm. Uses a dynamic target
+#' chunk size based on dataset size (log-scaled between 8 KB and 1 MB), and
+#' cycles through dimensions in round-robin fashion, halving each until the
+#' chunk fits within the target.
+#'
+#' See https://github.com/h5py/h5py/blob/62b4942/h5py/_hl/filters.py#L361
+#'
+#' @param dims Integer vector of dataset dimensions
+#' @param storage_mode Storage mode of the data ("double", "integer", etc.)
+#'
+#' @return Integer vector of chunk dimensions
+#'
+#' @noRd
+hdf5_auto_chunk <- function(dims, storage_mode) {
+  # h5py constants
+  chunk_base <- 16L * 1024L # 16 KB - multiplier for target calculation
+  chunk_min <- 8L * 1024L # 8 KB - soft lower limit
+  chunk_max <- 1024L * 1024L # 1 MB - hard upper limit
+
+  # Estimate bytes per element
+  element_bytes <- switch(
+    storage_mode,
+    double = 8L,
+    integer = 4L,
+    character = 16L, # variable-length strings: rough estimate
+    8L
+  )
+
+  ndims <- length(dims)
+  chunk <- as.double(dims)
+
+  # Compute dynamic target size using h5py's PyTables-derived expression
+  dset_size <- prod(chunk) * element_bytes
+  target_size <- chunk_base * (2^log10(dset_size / (1024 * 1024)))
+  target_size <- max(chunk_min, min(chunk_max, target_size))
+
+  # Round-robin halving of dimensions until within target
+  idx <- 0L
+  repeat {
+    chunk_bytes <- prod(chunk) * element_bytes
+
+    # Stop when:
+    # - chunk is smaller than target, OR within 50% of target, AND
+    # - chunk is smaller than the hard upper limit
+    if (
+      (chunk_bytes < target_size ||
+        abs(chunk_bytes - target_size) / target_size < 0.5) &&
+        chunk_bytes < chunk_max
+    ) {
+      break
+    }
+
+    # Can't reduce further
+    if (prod(chunk) == 1) {
+      break
+    }
+
+    dim_idx <- (idx %% ndims) + 1L
+    chunk[dim_idx] <- ceiling(chunk[dim_idx] / 2)
+    idx <- idx + 1L
+  }
+
+  as.integer(chunk)
 }

--- a/R/write_hdf5_helpers.R
+++ b/R/write_hdf5_helpers.R
@@ -334,11 +334,9 @@ hdf5_auto_chunk <- function(dims, storage_mode) {
     # Stop when:
     # - chunk is smaller than target, OR within 50% of target, AND
     # - chunk is smaller than the hard upper limit
-    if (
-      (chunk_bytes < target_size ||
-        abs(chunk_bytes - target_size) / target_size < 0.5) &&
-        chunk_bytes < chunk_max
-    ) {
+    is_within_target <- (chunk_bytes < target_size) ||
+      (abs(chunk_bytes - target_size) / target_size < 0.5)
+    if (is_within_target && chunk_bytes < chunk_max) {
       break
     }
 

--- a/man/AbstractAnnData.Rd
+++ b/man/AbstractAnnData.Rd
@@ -332,6 +332,7 @@ See \code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}} for more details on the conv
 \if{html}{\out{<div class="r">}}\preformatted{AbstractAnnData$as_HDF5AnnData(
   file,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   mode = c("w-", "r", "r+", "a", "w", "x")
 )}\if{html}{\out{</div>}}
 }
@@ -342,6 +343,8 @@ See \code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}} for more details on the conv
 \item{\code{file}}{See \code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}}}
 
 \item{\code{compression}}{See \code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}}}
+
+\item{\code{chunk_size}}{See \code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}}}
 
 \item{\code{mode}}{See \code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}}}
 }
@@ -362,6 +365,7 @@ See \code{\link[=write_h5ad]{write_h5ad()}} for details
 \if{html}{\out{<div class="r">}}\preformatted{AbstractAnnData$write_h5ad(
   path,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   mode = c("w-", "r", "r+", "a", "w", "x")
 )}\if{html}{\out{</div>}}
 }
@@ -372,6 +376,8 @@ See \code{\link[=write_h5ad]{write_h5ad()}} for details
 \item{\code{path}}{See \code{\link[=write_h5ad]{write_h5ad()}}}
 
 \item{\code{compression}}{See \code{\link[=write_h5ad]{write_h5ad()}}}
+
+\item{\code{chunk_size}}{See \code{\link[=write_h5ad]{write_h5ad()}}}
 
 \item{\code{mode}}{See \code{\link[=write_h5ad]{write_h5ad()}}}
 }

--- a/man/HDF5AnnData.Rd
+++ b/man/HDF5AnnData.Rd
@@ -108,7 +108,8 @@ Close the HDF5 file when the object is garbage collected
   uns = NULL,
   shape = NULL,
   mode = c("a", "r", "r+", "w", "w-", "x"),
-  compression = c("none", "gzip", "lzf")
+  compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto"
 )}\if{html}{\out{</div>}}
 }
 
@@ -143,6 +144,9 @@ both \code{X} or \code{obs} and \code{var} are not provided.}
 details}
 
 \item{\code{compression}}{The compression algorithm to use. See
+\code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}} for details}
+
+\item{\code{chunk_size}}{The target chunk size in bytes. See
 \code{\link[=as_HDF5AnnData]{as_HDF5AnnData()}} for details}
 }
 \if{html}{\out{</div>}}

--- a/man/as_HDF5AnnData.Rd
+++ b/man/as_HDF5AnnData.Rd
@@ -8,6 +8,7 @@ as_HDF5AnnData(
   adata,
   file,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   mode = c("w-", "r", "r+", "a", "w", "x")
 )
 }
@@ -19,6 +20,12 @@ as_HDF5AnnData(
 \item{compression}{The compression algorithm to use when writing the
 HDF5 file. Can be one of \code{"none"}, \code{"gzip"} or \code{"lzf"}. Defaults to
 \code{"none"}.}
+
+\item{chunk_size}{The target chunk size in bytes to use when writing
+HDF5 datasets. When \code{"auto"} (default), the chunk size is determined
+automatically using an algorithm that mimics h5py's auto-chunking
+behaviour. Set to \code{NULL} to disable chunking (contiguous storage,
+the rhdf5 default), or a number to use a specific target size in bytes.}
 
 \item{mode}{The mode to open the HDF5 file:
 \itemize{

--- a/man/write_h5ad.Rd
+++ b/man/write_h5ad.Rd
@@ -8,6 +8,7 @@ write_h5ad(
   object,
   path,
   compression = c("none", "gzip", "lzf"),
+  chunk_size = "auto",
   mode = c("w-", "r", "r+", "a", "w", "x"),
   ...
 )
@@ -21,6 +22,13 @@ write_h5ad(
 
 \item{compression}{The compression algorithm to use when writing the HDF5
 file. Can be one of \code{"none"}, \code{"gzip"} or \code{"lzf"}. Defaults to \code{"none"}.}
+
+\item{chunk_size}{The target chunk size in bytes to use when writing HDF5
+datasets. When \code{"auto"} (default), the chunk size is determined
+automatically using an algorithm that mimics h5py's auto-chunking
+behaviour. Set to \code{NULL} to disable chunking (contiguous storage,
+the rhdf5 default), or a number to use a specific target size in bytes.
+This only affects array-like datasets; scalar values are unaffected.}
 
 \item{mode}{The mode to open the HDF5 file.
 \itemize{

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -316,3 +316,38 @@ test_that("write_h5ad() warns about not writing matrix dim names", {
     expect_warning("Matrix row names cannot be written") |>
     expect_warning("Matrix column names cannot be written")
 })
+
+test_that("write_h5ad() chunk_size = NULL disables chunking", {
+  dummy <- generate_dataset(50, 100, format = "AnnData")
+  file <- withr::local_file(tempfile(fileext = ".h5ad"))
+
+  expect_no_error(write_h5ad(dummy, file, chunk_size = NULL))
+  expect_true(file.exists(file))
+
+  # Data should round-trip correctly with no chunking
+  result <- read_h5ad(file)
+  expect_equal(result$X, dummy$X)
+})
+
+test_that("write_h5ad() chunk_size = 'auto' (default) produces a valid file", {
+  dummy <- generate_dataset(50, 100, format = "AnnData")
+  file <- withr::local_file(tempfile(fileext = ".h5ad"))
+
+  expect_no_error(write_h5ad(dummy, file, chunk_size = "auto"))
+  expect_true(file.exists(file))
+
+  result <- read_h5ad(file)
+  expect_equal(result$X, dummy$X)
+})
+
+test_that("write_h5ad() chunk_size as a number uses it as target byte size", {
+  dummy <- generate_dataset(50, 100, format = "AnnData")
+  file <- withr::local_file(tempfile(fileext = ".h5ad"))
+
+  # 64 KB target
+  expect_no_error(write_h5ad(dummy, file, chunk_size = 64L * 1024L))
+  expect_true(file.exists(file))
+
+  result <- read_h5ad(file)
+  expect_equal(result$X, dummy$X)
+})

--- a/tests/testthat/test-hdf5_auto_chunk.R
+++ b/tests/testthat/test-hdf5_auto_chunk.R
@@ -1,0 +1,97 @@
+test_that("hdf5_auto_chunk returns integer vector", {
+  result <- hdf5_auto_chunk(c(100L, 50L), "double")
+  expect_type(result, "integer")
+})
+
+test_that("hdf5_auto_chunk preserves dimensionality", {
+  result_1d <- hdf5_auto_chunk(1000L, "double")
+  expect_length(result_1d, 1)
+
+  result_2d <- hdf5_auto_chunk(c(100L, 50L), "double")
+  expect_length(result_2d, 2)
+
+  result_3d <- hdf5_auto_chunk(c(100L, 50L, 30L), "double")
+  expect_length(result_3d, 3)
+})
+
+test_that("hdf5_auto_chunk doesn't exceed original dims", {
+  dims <- c(2000L, 1000L)
+  result <- hdf5_auto_chunk(dims, "double")
+  expect_true(all(result <= dims))
+})
+
+test_that("hdf5_auto_chunk keeps small datasets as-is", {
+  # 5 doubles = 40 bytes, well under any chunk target
+  result <- hdf5_auto_chunk(5L, "double")
+  expect_equal(result, 5L)
+
+  # 10x10 doubles = 800 bytes
+  result <- hdf5_auto_chunk(c(10L, 10L), "double")
+  expect_equal(result, c(10L, 10L))
+})
+
+test_that("hdf5_auto_chunk reduces large datasets", {
+  # 2000 x 1000 doubles = 16 MB, should be chunked below 1 MB
+  dims <- c(2000L, 1000L)
+  result <- hdf5_auto_chunk(dims, "double")
+  chunk_bytes <- prod(result) * 8L
+  expect_true(chunk_bytes < 1024L * 1024L)
+  expect_true(any(result < dims))
+})
+
+test_that("hdf5_auto_chunk handles very large datasets", {
+  # 50000 x 20000 doubles = 8 GB
+  dims <- c(50000L, 20000L)
+  result <- hdf5_auto_chunk(dims, "double")
+  chunk_bytes <- prod(result) * 8L
+  expect_true(chunk_bytes < 1024L * 1024L)
+  expect_true(all(result >= 1L))
+})
+
+test_that("hdf5_auto_chunk handles 1D vectors", {
+  # 2 million doubles = 16 MB
+  result <- hdf5_auto_chunk(2000000L, "double")
+  chunk_bytes <- result * 8L
+  expect_true(chunk_bytes < 1024L * 1024L)
+  expect_true(result >= 1L)
+})
+
+test_that("hdf5_auto_chunk respects storage mode", {
+  dims <- c(2000L, 1000L)
+
+  result_double <- hdf5_auto_chunk(dims, "double")
+  result_integer <- hdf5_auto_chunk(dims, "integer")
+
+  # Integer elements are 4 bytes vs 8 bytes for double,
+
+  # so integer chunks can be larger in element count
+  expect_true(prod(result_integer) >= prod(result_double))
+})
+
+test_that("hdf5_auto_chunk handles all storage modes", {
+  dims <- c(500L, 500L)
+
+  expect_no_error(hdf5_auto_chunk(dims, "double"))
+  expect_no_error(hdf5_auto_chunk(dims, "integer"))
+  expect_no_error(hdf5_auto_chunk(dims, "character"))
+  # Unknown mode falls back to 8 bytes
+  expect_no_error(hdf5_auto_chunk(dims, "raw"))
+})
+
+test_that("hdf5_auto_chunk produces positive chunk dimensions", {
+  # Edge case: very large dataset with small element size
+  result <- hdf5_auto_chunk(c(100000L, 100000L), "integer")
+  expect_true(all(result >= 1L))
+})
+
+test_that("hdf5_auto_chunk handles dimension of 1", {
+  # Tall skinny matrix: 1000000 x 1
+  result <- hdf5_auto_chunk(c(1000000L, 1L), "double")
+  expect_equal(result[2], 1L)
+  expect_true(result[1] <= 1000000L)
+
+  # Wide flat matrix: 1 x 1000000
+  result <- hdf5_auto_chunk(c(1L, 1000000L), "double")
+  expect_equal(result[1], 1L)
+  expect_true(result[2] <= 1000000L)
+})

--- a/tests/testthat/test-hdf5_auto_chunk.R
+++ b/tests/testthat/test-hdf5_auto_chunk.R
@@ -108,3 +108,17 @@ test_that("hdf5_auto_chunk respects explicit target_size", {
   result_512k <- hdf5_auto_chunk(dims, "double", target_size = 512L * 1024L)
   expect_true(prod(result_512k) >= prod(result_64k))
 })
+
+test_that("hdf5_auto_chunk avoids the 4 GB chunk limit (regression test for #415)", {
+  # The original report used n_obs x n_vars = 321427 x 17690 doubles.
+  # Without auto-chunking rhdf5 set chunk = dims, which at 8 bytes/element
+  # gives ~45 GB per chunk - exceeding HDF5's 4 GB hard limit.
+  # See https://github.com/scverse/anndataR/issues/415
+  dims <- c(321427L, 17690L)
+  result <- hdf5_auto_chunk(dims, "double")
+  chunk_bytes <- prod(as.numeric(result)) * 8
+  limit_4gb <- 4 * 1024^3
+  expect_true(chunk_bytes < limit_4gb)
+  # In practice it should be well within the 1 MB auto-chunk ceiling
+  expect_true(chunk_bytes <= 1024L * 1024L)
+})

--- a/tests/testthat/test-hdf5_auto_chunk.R
+++ b/tests/testthat/test-hdf5_auto_chunk.R
@@ -95,3 +95,16 @@ test_that("hdf5_auto_chunk handles dimension of 1", {
   expect_equal(result[1], 1L)
   expect_true(result[2] <= 1000000L)
 })
+
+test_that("hdf5_auto_chunk respects explicit target_size", {
+  dims <- c(2000L, 1000L)
+
+  # 64 KB target
+  result_64k <- hdf5_auto_chunk(dims, "double", target_size = 64L * 1024L)
+  chunk_bytes_64k <- prod(result_64k) * 8L
+  expect_true(chunk_bytes_64k <= 64L * 1024L * 1.5)
+
+  # 512 KB target should produce larger chunks than 64 KB target
+  result_512k <- hdf5_auto_chunk(dims, "double", target_size = 512L * 1024L)
+  expect_true(prod(result_512k) >= prod(result_64k))
+})


### PR DESCRIPTION
**Related to:** #415 

## Description

Improves HDF5 write performance by auto-chunking datasets, and adds a
`chunk_size` parameter to `write_h5ad()` to allow manual control over chunk
sizes.

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [x] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [ ] Bump devel version
