### PR TITLE
Update links to `{pkgdown}` site

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -11,4 +11,4 @@ open_collective: anndatar
 # lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
 # polar: # Replace with a single Polar username
 # buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-custom: https://www.data-intuitive.com
+# custom: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Description: Bring the power and flexibility of AnnData to the R
     files, directly access various slots (e.g. X, obs, var), or convert
     the data into SingleCellExperiment and Seurat objects.
 License: MIT + file LICENSE
-URL: https://anndatar.scverse.org,
+URL: https://scverse.org/anndataR/,
     https://github.com/scverse/anndataR
 BugReports: https://github.com/scverse/anndataR/issues
 Depends: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: anndataR
 Title: AnnData interoperability in R
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("Robrecht", "Cannoodt", , "rcannood@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Description: Bring the power and flexibility of AnnData to the R
     files, directly access various slots (e.g. X, obs, var), or convert
     the data into SingleCellExperiment and Seurat objects.
 License: MIT + file LICENSE
-URL: https://scverse.org/anndataR/,
+URL: https://anndataR.scverse.org/,
     https://github.com/scverse/anndataR
 BugReports: https://github.com/scverse/anndataR/issues
 Depends: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# anndataR 1.1.2
+
+- Fix broken links (PR #429).
+
 # anndataR 1.1.1
 
 - Fix CI (PR #418).
@@ -10,6 +14,10 @@
 # anndataR 1.1.0
 
 - Bioconductor 3.23 devel
+
+# anndataR 1.0.2
+
+- Fix broken links (PR #430).
 
 # anndataR 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - Convert to/from `SingleCellExperiment` objects
 - Convert to/from `Seurat` objects
 
-You can find the status of development of **{anndataR}** on the [feature tracking page](https://anndatar.data-intuitive.com/articles/design.html#feature-tracking) of the package website.
+You can find the design concepts in the [Software Design vignette](https://anndataR.scverse.org/articles/software_design.html).
 Please [report](https://github.com/scverse/anndataR/issues) any issues you encounter.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 - Convert to/from `SingleCellExperiment` objects
 - Convert to/from `Seurat` objects
 
-You can find the design concepts in the [Software Design vignette](https://anndataR.scverse.org/articles/software_design.html).
 Please [report](https://github.com/scverse/anndataR/issues) any issues you encounter.
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ pak::pak("scverse/anndataR")
 
 Take note that you need all suggested dependencies available, and that building them can take some time.
 
-- [**Getting started**](https://anndatar.data-intuitive.com/articles/anndataR.html): An introduction to the package and its features.  
+- [**Getting started**](https://scverse.org/anndataR/articles/anndataR.html): An introduction to the package and its features.  
   `vignette("anndataR", package = "anndataR")`
-- [**Read/write `Seurat` objects**](https://anndatar.data-intuitive.com/articles/usage_seurat.html): How to convert between `AnnData` and `Seurat` objects.  
+- [**Read/write `Seurat` objects**](https://scverse.org/anndataR/articles/usage_seurat.html): How to convert between `AnnData` and `Seurat` objects.  
   `vignette("usage_seurat", package = "anndataR")`
-- [**Read/write `SingleCellExperiment` objects**](https://anndatar.data-intuitive.com/articles/usage_singlecellexperiment.html): How to convert between `AnnData` and `SingleCellExperiment` objects  
+- [**Read/write `SingleCellExperiment` objects**](https://scverse.org/anndataR/articles/usage_singlecellexperiment.html): How to convert between `AnnData` and `SingleCellExperiment` objects  
   `vignette("usage_singlecellexperiment", package = "anndataR")`
-- [**Software Design**](https://anndatar.data-intuitive.com/articles/software_design.html): An overview of the design of the package
-- [**Development Status**](https://anndatar.data-intuitive.com/articles/development_status.html): An overview of the development status of the package
+- [**Software Design**](https://scverse.org/anndataR/articles/software_design.html): An overview of the design of the package
+- [**Development Status**](https://scverse.org/anndataR/articles/development_status.html): An overview of the development status of the package
 
 ## Citing **{anndataR}**
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ pak::pak("scverse/anndataR")
 
 Take note that you need all suggested dependencies available, and that building them can take some time.
 
-- [**Getting started**](https://scverse.org/anndataR/articles/anndataR.html): An introduction to the package and its features.  
+- [**Getting started**](https://anndataR.scverse.org/articles/anndataR.html): An introduction to the package and its features.  
   `vignette("anndataR", package = "anndataR")`
-- [**Read/write `Seurat` objects**](https://scverse.org/anndataR/articles/usage_seurat.html): How to convert between `AnnData` and `Seurat` objects.  
+- [**Read/write `Seurat` objects**](https://anndataR.scverse.org/articles/usage_seurat.html): How to convert between `AnnData` and `Seurat` objects.  
   `vignette("usage_seurat", package = "anndataR")`
-- [**Read/write `SingleCellExperiment` objects**](https://scverse.org/anndataR/articles/usage_singlecellexperiment.html): How to convert between `AnnData` and `SingleCellExperiment` objects  
+- [**Read/write `SingleCellExperiment` objects**](https://anndataR.scverse.org/articles/usage_singlecellexperiment.html): How to convert between `AnnData` and `SingleCellExperiment` objects  
   `vignette("usage_singlecellexperiment", package = "anndataR")`
-- [**Software Design**](https://scverse.org/anndataR/articles/software_design.html): An overview of the design of the package
-- [**Development Status**](https://scverse.org/anndataR/articles/development_status.html): An overview of the development status of the package
+- [**Software Design**](https://anndataR.scverse.org/articles/software_design.html): An overview of the design of the package
+- [**Development Status**](https://anndataR.scverse.org/articles/development_status.html): An overview of the development status of the package
 
 ## Citing **{anndataR}**
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pak::pak("scverse/anndataR", dependencies = TRUE)
 
 ## Getting started
 
-The best way to get started with **{anndataR}** is to explore the package vignettes (available at https://anndatar.data-intuitive.com/articles/).
+The best way to get started with **{anndataR}** is to explore the package vignettes (available at https://anndataR.scverse.org/articles/).
 
 In order to browse these vignettes locally, you need to build them during installation:
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://anndataR.data-intuitive.com
+url: https://scverse.org/anndataR/
 
 template:
   bootstrap: 5

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://scverse.org/anndataR/
+url: https://anndataR.scverse.org/
 
 template:
   bootstrap: 5

--- a/man/anndataR-package.Rd
+++ b/man/anndataR-package.Rd
@@ -13,7 +13,7 @@ Bring the power and flexibility of AnnData to the R ecosystem, allowing you to e
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://scverse.org/anndataR/}
+  \item \url{https://anndataR.scverse.org/}
   \item \url{https://github.com/scverse/anndataR}
   \item Report bugs at \url{https://github.com/scverse/anndataR/issues}
 }

--- a/man/anndataR-package.Rd
+++ b/man/anndataR-package.Rd
@@ -13,7 +13,7 @@ Bring the power and flexibility of AnnData to the R ecosystem, allowing you to e
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://anndatar.scverse.org}
+  \item \url{https://scverse.org/anndataR/}
   \item \url{https://github.com/scverse/anndataR}
   \item Report bugs at \url{https://github.com/scverse/anndataR/issues}
 }

--- a/tests/testthat/test-roundtrip-obsmvarm.R
+++ b/tests/testthat/test-roundtrip-obsmvarm.R
@@ -15,7 +15,7 @@ test_names <- c(
 )
 
 # temporary workaround for
-# https://github.com/data-intuitive/dummy-anndata/issues/12
+# https://github.com/LouiseDck/dummy-anndata/issues/12
 test_names <- setdiff(
   test_names,
   c(


### PR DESCRIPTION
**Related to:** Fixes #428 

## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

Update links so they point to the current **{pkgdown}** site URL

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
