### PR TITLE
Delayed array improvements

### DIFF
--- a/R/AnnDataView.R
+++ b/R/AnnDataView.R
@@ -46,8 +46,13 @@ AnnDataView <- R6::R6Class(
         return(x)
       }
 
-      # Check if x is a subsettable matrix-like object (data.frame, matrix, or Matrix)
-      if (is.data.frame(x) || is.matrix(x) || inherits(x, "Matrix")) {
+      # Check if x is a subsettable matrix-like object
+      if (
+        is.data.frame(x) ||
+          is.matrix(x) ||
+          inherits(x, "Matrix") ||
+          inherits(x, "DelayedArray")
+      ) {
         result <- x
 
         # Apply obs subsetting to rows if requested

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -558,6 +558,20 @@ HDF5AnnData <- R6::R6Class(
     #' @description Close the HDF5 file handle
     close = function() {
       private$.hdf5_file$close()
+    },
+
+    #' @description Convert to an [`InMemoryAnnData`]. Any backed
+    #'   (`DelayedArray`) slots are materialized into ordinary in-memory
+    #'   matrices: an in-memory object should not stay tied to an on-disk file.
+    as_InMemoryAnnData = function() {
+      if (isTRUE(private$.backed)) {
+        prev <- private$.backed
+        private$.backed <- FALSE
+        on.exit(private$.backed <- prev, add = TRUE)
+        # Hold the file open for the whole multi-slot read (single handle).
+        private$.hdf5_file$open_and_defer_close(readonly = TRUE)
+      }
+      super$as_InMemoryAnnData()
     }
   )
 )

--- a/R/HDF5AnnData.R
+++ b/R/HDF5AnnData.R
@@ -357,7 +357,7 @@ HDF5AnnData <- R6::R6Class(
       compression = c("none", "gzip", "lzf"),
       chunk_size = "auto"
     ) {
-      check_requires("HDF5AnnData", c("rhdf5", "HDF5Array"), where = "Bioc")
+      check_requires("HDF5AnnData", "rhdf5", where = "Bioc")
       check_requires("HDF5AnnData", "withr", where = "CRAN")
 
       compression <- match.arg(compression)
@@ -392,6 +392,14 @@ HDF5AnnData <- R6::R6Class(
         backed <- FALSE
       }
       private$.backed <- backed
+
+      if (isTRUE(private$.backed)) {
+        check_requires(
+          "Reading a backed HDF5AnnData",
+          c("HDF5Array", "DelayedArray"),
+          where = "Bioc"
+        )
+      }
 
       # Fail is the file does not exist and in read mode
       if (!file.exists(file) && mode %in% c("r", "r+")) {

--- a/R/HDF5File.R
+++ b/R/HDF5File.R
@@ -58,15 +58,11 @@ HDF5File <- R6::R6Class(
     #'
     #' @return `TRUE` if the handle was successfully opened (invisibly)
     open = function(readonly = FALSE) {
-      if (
-        self$is_open &&
-          private$.handle_is_valid() &&
-          (self$is_readonly == readonly)
-      ) {
-        return(invisible(TRUE))
-      }
-
-      if (self$is_readonly != readonly) {
+      # Reuse the open handle if it already grants enough access
+      if (self$is_open && private$.handle_is_valid()) {
+        if (readonly || !self$is_readonly) {
+          return(invisible(TRUE))
+        }
         self$close()
       }
 

--- a/R/from_SingleCellExperiment.R
+++ b/R/from_SingleCellExperiment.R
@@ -234,6 +234,12 @@ from_SingleCellExperiment <- function(
     as.data.frame(object)
   } else if (inherits(object, "SimpleList")) {
     as.list(object)
+  } else if (inherits(object, "DelayedArray")) {
+    if (transpose) {
+      DelayedArray::t(object)
+    } else {
+      object
+    }
   } else if (inherits(object, "matrix") || inherits(object, "Matrix")) {
     if (inherits(object, "denseMatrix")) {
       object <- as.matrix(object)

--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -215,6 +215,11 @@ read_h5ad_dense_array <- function(
 ) {
   version <- match.arg(version)
 
+  # Eager reads use base {rhdf5} directly
+  if (!isTRUE(backed)) {
+    return(read_h5ad_dense_array_base(hdf5_file, name, version))
+  }
+
   dataset_type <- hdf5_get_dataset_type(hdf5_file, name)
   if (dataset_type == "H5T_INTEGER") {
     dataset_type <- "integer"
@@ -233,10 +238,6 @@ read_h5ad_dense_array <- function(
     data <- t(data)
   } else if (length(dim(data)) > 2) {
     data <- aperm(data)
-  }
-
-  if (!isTRUE(backed)) {
-    data <- as.array(data)
   }
 
   data
@@ -332,20 +333,13 @@ read_h5ad_sparse_array <- function(
   version <- match.arg(version)
   type <- match.arg(type)
 
-  hdf5_file$close_and_defer_open()
-  mtx <- t(HDF5Array::H5SparseMatrix(hdf5_file$path, name))
-
-  if (!backed) {
-    mtx <- if (type == "csc_matrix") {
-      as(mtx, "dgCMatrix")
-    } else if (type == "csr_matrix") {
-      mtx |>
-        as("COO_SparseArray") |>
-        as("dgRMatrix")
-    }
+  # Eager reads use base {rhdf5} directly
+  if (!isTRUE(backed)) {
+    return(read_h5ad_sparse_array_base(hdf5_file, name, version, type))
   }
 
-  mtx
+  hdf5_file$close_and_defer_open()
+  t(HDF5Array::H5SparseMatrix(hdf5_file$path, name))
 }
 
 #' Read H5AD sparse array (base)

--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -136,6 +136,8 @@ read_h5ad_element_keys <- function(
   stop_on_error = FALSE,
   ...
 ) {
+  file$open_and_defer_close(readonly = TRUE)
+
   if (!hdf5_path_exists(file, name)) {
     return(NULL)
   }

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -28,6 +28,15 @@ write_h5ad_element <- function(
 ) {
   compression <- match.arg(compression)
 
+  # Materialize on write
+  if (inherits(value, "DelayedArray")) {
+    value <- if (DelayedArray::is_sparse(value)) {
+      as(value, "CsparseMatrix")
+    } else {
+      as.matrix(value)
+    }
+  }
+
   # Sparse matrices
   write_fun <-
     if (is.null(value)) {

--- a/benchmarks/suites/bench_read.R
+++ b/benchmarks/suites/bench_read.R
@@ -35,6 +35,21 @@ bench_read <- function(h5ad_paths, iterations, x_types, zarr_paths) {
         iterations = iterations
       )
     )
+
+    # Read X lazily
+    results <- c(
+      results,
+      run_one_benchmark(
+        name = paste0("read_HDF5_backed_X_", xt),
+        expr = quote({
+          ad <- read_h5ad(.path, as = "HDF5AnnData", backed = TRUE)
+          force(ad$X)
+          ad$close()
+        }),
+        setup = bquote(.path <- .(path)),
+        iterations = iterations
+      )
+    )
   }
 
   # Read from Zarr store

--- a/inst/known_issues.yaml
+++ b/inst/known_issues.yaml
@@ -29,19 +29,3 @@ known_issues:
       CsparseMatrix, dense to base matrix) before the normal write dispatch.
     to_investigate: False
     to_fix: True
-  - backend: backed
-    slot: [X]
-    dtype: [delayed]
-    process: [to_AnnData]
-    error_message: |
-      Unexpected shape for layers[['counts']]
-    description: >
-      Converting a backed SingleCellExperiment back to AnnData transposes the
-      matrix and fails shape validation. The backed assay (a DelayedMatrix from
-      H5SparseMatrix/HDF5Array) is oriented transposed relative to AnnData and
-      the reverse conversion does not account for it.
-    proposed_solution: >
-      Handle DelayedArray orientation when converting a backed SCE/Seurat back to
-      AnnData (transpose/realize as needed).
-    to_investigate: False
-    to_fix: True

--- a/inst/known_issues.yaml
+++ b/inst/known_issues.yaml
@@ -18,22 +18,6 @@ known_issues:
   - backend: backed
     slot: [X]
     dtype: [delayed]
-    process: [subset]
-    error_message: |
-      dim(vb$X) not equal to c(length(oi), length(vi)); the full, unsubset
-      matrix is returned.
-    description: >
-      Subsetting a backed AnnData returns the full matrix instead of the subset.
-      AnnDataView$.apply_subset() only recognises data.frame/matrix/Matrix, so a
-      DelayedMatrix falls through the guard unchanged.
-    proposed_solution: >
-      In AnnDataView$.apply_subset(), also handle DelayedArray (e.g. add
-      `|| inherits(x, "DelayedArray")` to the guard) so backed slots are subset.
-    to_investigate: False
-    to_fix: True
-  - backend: backed
-    slot: [X]
-    dtype: [delayed]
     process: [to_InMemory]
     error_message: |
       inherits(im$X, "DelayedArray") is TRUE; expected a materialized matrix.

--- a/inst/known_issues.yaml
+++ b/inst/known_issues.yaml
@@ -15,17 +15,3 @@ known_issues:
     proposed_solution: Investigate if this is a problem or not.
     to_investigate: True
     to_fix: False
-  - backend: backed
-    slot: [X]
-    dtype: [delayed]
-    process: [write]
-    error_message: |
-      Writing <DelayedMatrix> objects to H5AD is not supported
-    description: >
-      Writing a backed AnnData aborts because its DelayedMatrix slots are not
-      materialized before writing.
-    proposed_solution: >
-      In write_h5ad_element(), materialize DelayedArray values (sparse to
-      CsparseMatrix, dense to base matrix) before the normal write dispatch.
-    to_investigate: False
-    to_fix: True

--- a/inst/known_issues.yaml
+++ b/inst/known_issues.yaml
@@ -18,22 +18,6 @@ known_issues:
   - backend: backed
     slot: [X]
     dtype: [delayed]
-    process: [to_InMemory]
-    error_message: |
-      inherits(im$X, "DelayedArray") is TRUE; expected a materialized matrix.
-    description: >
-      Converting a backed HDF5AnnData to InMemoryAnnData keeps DelayedArray
-      slots instead of materializing them; an in-memory object should not be
-      backed by an on-disk file.
-    proposed_solution: >
-      Override HDF5AnnData$as_InMemoryAnnData() to realize DelayedArray slots
-      (sparse stays sparse, dense becomes a base matrix) before constructing the
-      InMemoryAnnData.
-    to_investigate: False
-    to_fix: True
-  - backend: backed
-    slot: [X]
-    dtype: [delayed]
     process: [write]
     error_message: |
       Writing <DelayedMatrix> objects to H5AD is not supported

--- a/inst/known_issues.yaml
+++ b/inst/known_issues.yaml
@@ -15,3 +15,65 @@ known_issues:
     proposed_solution: Investigate if this is a problem or not.
     to_investigate: True
     to_fix: False
+  - backend: backed
+    slot: [X]
+    dtype: [delayed]
+    process: [subset]
+    error_message: |
+      dim(vb$X) not equal to c(length(oi), length(vi)); the full, unsubset
+      matrix is returned.
+    description: >
+      Subsetting a backed AnnData returns the full matrix instead of the subset.
+      AnnDataView$.apply_subset() only recognises data.frame/matrix/Matrix, so a
+      DelayedMatrix falls through the guard unchanged.
+    proposed_solution: >
+      In AnnDataView$.apply_subset(), also handle DelayedArray (e.g. add
+      `|| inherits(x, "DelayedArray")` to the guard) so backed slots are subset.
+    to_investigate: False
+    to_fix: True
+  - backend: backed
+    slot: [X]
+    dtype: [delayed]
+    process: [to_InMemory]
+    error_message: |
+      inherits(im$X, "DelayedArray") is TRUE; expected a materialized matrix.
+    description: >
+      Converting a backed HDF5AnnData to InMemoryAnnData keeps DelayedArray
+      slots instead of materializing them; an in-memory object should not be
+      backed by an on-disk file.
+    proposed_solution: >
+      Override HDF5AnnData$as_InMemoryAnnData() to realize DelayedArray slots
+      (sparse stays sparse, dense becomes a base matrix) before constructing the
+      InMemoryAnnData.
+    to_investigate: False
+    to_fix: True
+  - backend: backed
+    slot: [X]
+    dtype: [delayed]
+    process: [write]
+    error_message: |
+      Writing <DelayedMatrix> objects to H5AD is not supported
+    description: >
+      Writing a backed AnnData aborts because its DelayedMatrix slots are not
+      materialized before writing.
+    proposed_solution: >
+      In write_h5ad_element(), materialize DelayedArray values (sparse to
+      CsparseMatrix, dense to base matrix) before the normal write dispatch.
+    to_investigate: False
+    to_fix: True
+  - backend: backed
+    slot: [X]
+    dtype: [delayed]
+    process: [to_AnnData]
+    error_message: |
+      Unexpected shape for layers[['counts']]
+    description: >
+      Converting a backed SingleCellExperiment back to AnnData transposes the
+      matrix and fails shape validation. The backed assay (a DelayedMatrix from
+      H5SparseMatrix/HDF5Array) is oriented transposed relative to AnnData and
+      the reverse conversion does not account for it.
+    proposed_solution: >
+      Handle DelayedArray orientation when converting a backed SCE/Seurat back to
+      AnnData (transpose/realize as needed).
+    to_investigate: False
+    to_fix: True

--- a/man/HDF5AnnData.Rd
+++ b/man/HDF5AnnData.Rd
@@ -72,12 +72,12 @@ Other AnnData classes:
     \item \href{#method-HDF5AnnData-n_vars}{\code{HDF5AnnData$n_vars()}}
     \item \href{#method-HDF5AnnData-open}{\code{HDF5AnnData$open()}}
     \item \href{#method-HDF5AnnData-close}{\code{HDF5AnnData$close()}}
+    \item \href{#method-HDF5AnnData-as_InMemoryAnnData}{\code{HDF5AnnData$as_InMemoryAnnData()}}
   }
 }
 \if{html}{\out{<details><summary>Inherited methods</summary>
 <ul>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_HDF5AnnData"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_HDF5AnnData'><code>AbstractAnnData$as_HDF5AnnData()</code></a></span></li>
-  <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_InMemoryAnnData"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_InMemoryAnnData'><code>AbstractAnnData$as_InMemoryAnnData()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_ReticulateAnnData"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_ReticulateAnnData'><code>AbstractAnnData$as_ReticulateAnnData()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_Seurat"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_Seurat'><code>AbstractAnnData$as_Seurat()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_SingleCellExperiment"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_SingleCellExperiment'><code>AbstractAnnData$as_SingleCellExperiment()</code></a></span></li>
@@ -296,6 +296,22 @@ file will be overwritten.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{HDF5AnnData$close()}
+    \if{html}{\out{</div>}}
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-HDF5AnnData-as_InMemoryAnnData"></a>}}
+\if{latex}{\out{\hypertarget{method-HDF5AnnData-as_InMemoryAnnData}{}}}
+\subsection{\code{HDF5AnnData$as_InMemoryAnnData()}}{
+  Convert to an \code{\link{InMemoryAnnData}}. Any backed
+(\code{DelayedArray}) slots are materialized into ordinary in-memory
+matrices: an in-memory object should not stay tied to an on-disk file.
+Slots are read eagerly (via base {rhdf5}) rather than carried over as
+DelayedArrays, which is also faster than realizing them.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{HDF5AnnData$as_InMemoryAnnData()}
     \if{html}{\out{</div>}}
   }
 }

--- a/tests/testthat/test-HDF5-read.R
+++ b/tests/testthat/test-HDF5-read.R
@@ -6,6 +6,8 @@ requireNamespace("vctrs")
 filename <- system.file("extdata", "example.h5ad", package = "anndataR")
 hdf5_file <- HDF5File$new(filename)
 
+known_issues <- read_known_issues()
+
 test_that("reading encoding works", {
   encoding <- read_h5ad_encoding(hdf5_file, "obs")
   expect_equal(names(encoding), c("type", "version"))
@@ -75,6 +77,192 @@ test_that("reading backed sparse matrices works", {
   expect_identical(DelayedArray::type(seed), "double")
   expect_true(DelayedArray::is_sparse(seed))
   expect_equal(dim(mat), c(50, 100))
+})
+
+# INVARIANT: backed dense reads must equal an INDEPENDENT eager read
+test_that("backed dense reads are value-identical to independent eager reads", {
+  for (nm in c("layers/dense_counts", "layers/dense_X")) {
+    eager <- read_h5ad_dense_array_base(hdf5_file, nm)
+    backed <- read_h5ad_dense_array(hdf5_file, nm, backed = TRUE)
+    expect_s4_class(backed, "DelayedMatrix")
+    expect_equal(as.matrix(backed), eager)
+    raw <- rhdf5::h5read(filename, nm) # on-disk orientation is vars x obs
+    expect_equal(as.matrix(backed), t(raw), ignore_attr = TRUE)
+  }
+})
+
+# INVARIANT: backed sparse reads must equal independent eager reads and stay
+# sparse.
+test_that("backed sparse reads are value-identical to independent eager reads", {
+  cases <- list(
+    list(name = "layers/csc_counts", type = "csc_matrix"),
+    list(name = "layers/counts", type = "csr_matrix")
+  )
+  for (case in cases) {
+    eager <- read_h5ad_sparse_array_base(hdf5_file, case$name, type = case$type)
+    backed <- read_h5ad_sparse_array(
+      hdf5_file,
+      case$name,
+      type = case$type,
+      backed = TRUE
+    )
+    expect_s4_class(backed, "DelayedMatrix")
+    expect_true(DelayedArray::is_sparse(backed))
+    expect_equal(as.matrix(backed), as.matrix(eager))
+  }
+})
+
+# INVARIANT: a backed HDF5AnnData exposes the same matrices (values, dimnames,
+# orientation) as an eager one, for every matrix-valued slot.
+test_that("backed HDF5AnnData slots equal eager slots", {
+  eager <- HDF5AnnData$new(filename, mode = "r")
+  backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
+  withr::defer({
+    eager$close()
+    backed$close()
+  })
+
+  expect_s4_class(backed$X, "DelayedMatrix")
+  expect_equal(as.matrix(backed$X), as.matrix(eager$X))
+  expect_identical(dimnames(backed$X), dimnames(eager$X))
+
+  for (k in eager$layers_keys()) {
+    expect_equal(
+      as.matrix(backed$layers[[k]]),
+      as.matrix(eager$layers[[k]]),
+      info = paste("layer", k)
+    )
+  }
+  for (k in names(eager$obsm)) {
+    expect_equal(
+      as.matrix(backed$obsm[[k]]),
+      as.matrix(eager$obsm[[k]]),
+      info = paste("obsm", k)
+    )
+  }
+  for (k in names(eager$obsp)) {
+    expect_equal(
+      as.matrix(backed$obsp[[k]]),
+      as.matrix(eager$obsp[[k]]),
+      info = paste("obsp", k)
+    )
+  }
+})
+
+# INVARIANT: a backed matrix reads lazily by file path, so it must keep working
+# after the source AnnData is closed and garbage-collected.
+test_that("backed matrices stay readable after the source AnnData is closed", {
+  eager <- HDF5AnnData$new(filename, mode = "r")
+  expected <- as.matrix(eager$X)
+  eager$close()
+
+  backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
+  x_backed <- backed$X
+  expect_s4_class(x_backed, "DelayedMatrix")
+  backed$close()
+  rm(backed)
+  gc()
+
+  expect_equal(as.matrix(x_backed), expected)
+})
+
+# BUG #1: subsetting a backed AnnData must stay lazy AND apply the subset.
+# AnnDataView$.apply_subset() only recognises data.frame/matrix/{Matrix}, so a
+# DelayedMatrix falls through the guard and the FULL (unsubset) matrix is
+# returned.
+test_that("subsetting a backed AnnData stays lazy and subsets correctly", {
+  msg <- message_if_known(
+    backend = "backed",
+    slot = "X",
+    dtype = "delayed",
+    process = "subset",
+    known_issues = known_issues
+  )
+  skip_if(!is.null(msg), message = msg)
+
+  backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
+  eager <- HDF5AnnData$new(filename, mode = "r")
+  withr::defer({
+    backed$close()
+    eager$close()
+  })
+
+  oi <- c(1, 3, 5, 7, 9)
+  vi <- 1:10
+  vb <- backed[oi, vi]
+  ve <- eager[oi, vi]
+
+  expect_s4_class(vb$X, "DelayedMatrix")
+  expect_equal(dim(vb$X), c(length(oi), length(vi)))
+  expect_equal(as.matrix(vb$X), as.matrix(ve$X))
+})
+
+# BUG #2: converting a backed AnnData to InMemory should materialize its
+# DelayedArrays into ordinary in-memory matrices (an in-memory object backed by
+# an on-disk file makes no sense). Baseline carries the DelayedMatrix through.
+test_that("converting a backed AnnData to InMemory materializes its matrices", {
+  msg <- message_if_known(
+    backend = "backed",
+    slot = "X",
+    dtype = "delayed",
+    process = "to_InMemory",
+    known_issues = known_issues
+  )
+  skip_if(!is.null(msg), message = msg)
+
+  backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
+  withr::defer(backed$close())
+  im <- backed$as_InMemoryAnnData()
+
+  expect_false(inherits(im$X, "DelayedArray"))
+  expect_equal(as.matrix(im$X), as.matrix(backed$X))
+})
+
+# INVARIANT: a backed SingleCellExperiment keeps its assays lazy (DelayedMatrix)
+# and value-equal to an eager conversion.
+test_that("backed SingleCellExperiment has lazy assays equal to eager ones", {
+  suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
+
+  backed <- read_h5ad(filename, as = "HDF5AnnData", backed = TRUE)
+  eager <- read_h5ad(filename, as = "HDF5AnnData")
+  withr::defer({
+    backed$close()
+    eager$close()
+  })
+
+  sce_b <- backed$as_SingleCellExperiment()
+  sce_e <- eager$as_SingleCellExperiment()
+  for (a in SummarizedExperiment::assayNames(sce_e)) {
+    expect_s4_class(SummarizedExperiment::assay(sce_b, a), "DelayedMatrix")
+    expect_equal(
+      as.matrix(SummarizedExperiment::assay(sce_b, a)),
+      as.matrix(SummarizedExperiment::assay(sce_e, a)),
+      info = paste("assay", a)
+    )
+  }
+})
+
+# BUG (issue #387, reported by LouiseDck): converting a backed SCE back to
+# AnnData transposes the matrix and fails shape validation. The backed assay (a
+# DelayedMatrix from H5SparseMatrix/HDF5Array) is oriented transposed relative to
+# AnnData and the reverse conversion does not account for it.
+test_that("round-trip of a backed SCE back to AnnData preserves shape", {
+  msg <- message_if_known(
+    backend = "backed",
+    slot = "X",
+    dtype = "delayed",
+    process = "to_AnnData",
+    known_issues = known_issues
+  )
+  skip_if(!is.null(msg), message = msg)
+  suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
+
+  backed <- read_h5ad(filename, as = "HDF5AnnData", backed = TRUE)
+  withr::defer(backed$close())
+  sce_backed <- backed$as_SingleCellExperiment()
+
+  ad2 <- as_AnnData(sce_backed)
+  expect_equal(ad2$shape(), backed$shape())
 })
 
 test_that("reading recarrays works", {

--- a/tests/testthat/test-HDF5-read.R
+++ b/tests/testthat/test-HDF5-read.R
@@ -6,8 +6,6 @@ requireNamespace("vctrs")
 filename <- system.file("extdata", "example.h5ad", package = "anndataR")
 hdf5_file <- HDF5File$new(filename)
 
-known_issues <- read_known_issues()
-
 test_that("reading encoding works", {
   encoding <- read_h5ad_encoding(hdf5_file, "obs")
   expect_equal(names(encoding), c("type", "version"))
@@ -166,20 +164,9 @@ test_that("backed matrices stay readable after the source AnnData is closed", {
   expect_equal(as.matrix(x_backed), expected)
 })
 
-# BUG #1: subsetting a backed AnnData must stay lazy AND apply the subset.
-# AnnDataView$.apply_subset() only recognises data.frame/matrix/{Matrix}, so a
-# DelayedMatrix falls through the guard and the FULL (unsubset) matrix is
-# returned.
+# Regression test: subsetting a backed AnnData must stay lazy AND apply the
+# subset.
 test_that("subsetting a backed AnnData stays lazy and subsets correctly", {
-  msg <- message_if_known(
-    backend = "backed",
-    slot = "X",
-    dtype = "delayed",
-    process = "subset",
-    known_issues = known_issues
-  )
-  skip_if(!is.null(msg), message = msg)
-
   backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
   eager <- HDF5AnnData$new(filename, mode = "r")
   withr::defer({
@@ -197,19 +184,9 @@ test_that("subsetting a backed AnnData stays lazy and subsets correctly", {
   expect_equal(as.matrix(vb$X), as.matrix(ve$X))
 })
 
-# BUG #2: converting a backed AnnData to InMemory should materialize its
-# DelayedArrays into ordinary in-memory matrices (an in-memory object backed by
-# an on-disk file makes no sense). Baseline carries the DelayedMatrix through.
+# Regression test: converting a backed AnnData to InMemory must materialize its
+# DelayedArrays into ordinary in-memory matrices
 test_that("converting a backed AnnData to InMemory materializes its matrices", {
-  msg <- message_if_known(
-    backend = "backed",
-    slot = "X",
-    dtype = "delayed",
-    process = "to_InMemory",
-    known_issues = known_issues
-  )
-  skip_if(!is.null(msg), message = msg)
-
   backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
   withr::defer(backed$close())
   im <- backed$as_InMemoryAnnData()
@@ -242,19 +219,9 @@ test_that("backed SingleCellExperiment has lazy assays equal to eager ones", {
   }
 })
 
-# BUG (issue #387, reported by LouiseDck): converting a backed SCE back to
-# AnnData transposes the matrix and fails shape validation. The backed assay (a
-# DelayedMatrix from H5SparseMatrix/HDF5Array) is oriented transposed relative to
-# AnnData and the reverse conversion does not account for it.
+# Regression test (issue #387, reported by LouiseDck): converting a backed SCE
+# back to AnnData must preserve shape.
 test_that("round-trip of a backed SCE back to AnnData preserves shape", {
-  msg <- message_if_known(
-    backend = "backed",
-    slot = "X",
-    dtype = "delayed",
-    process = "to_AnnData",
-    known_issues = known_issues
-  )
-  skip_if(!is.null(msg), message = msg)
   suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
 
   backed <- read_h5ad(filename, as = "HDF5AnnData", backed = TRUE)

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -3,8 +3,6 @@ skip_if_not_installed("HDF5Array")
 
 requireNamespace("vctrs")
 
-known_issues <- read_known_issues()
-
 file <- tempfile(pattern = "hdf5_write_", fileext = ".h5ad")
 if (file.exists(file)) {
   file.remove(file)
@@ -438,18 +436,7 @@ test_that("write_h5ad() chunk_size as a number uses it as target byte size", {
   expect_equal(result$X, dummy$X)
 })
 
-# BUG (PR #387): writing a backed AnnData should materialize its
-# DelayedMatrix slots
 test_that("writing a backed AnnData materializes its DelayedMatrix slots", {
-  msg <- message_if_known(
-    backend = "backed",
-    slot = "X",
-    dtype = "delayed",
-    process = "write",
-    known_issues = known_issues
-  )
-  skip_if(!is.null(msg), message = msg)
-
   filename <- system.file("extdata", "example.h5ad", package = "anndataR")
   backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
   withr::defer(backed$close())

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -3,6 +3,8 @@ skip_if_not_installed("HDF5Array")
 
 requireNamespace("vctrs")
 
+known_issues <- read_known_issues()
+
 file <- tempfile(pattern = "hdf5_write_", fileext = ".h5ad")
 if (file.exists(file)) {
   file.remove(file)
@@ -434,4 +436,29 @@ test_that("write_h5ad() chunk_size as a number uses it as target byte size", {
 
   result <- read_h5ad(file)
   expect_equal(result$X, dummy$X)
+})
+
+# BUG (PR #387): writing a backed AnnData should materialize its
+# DelayedMatrix slots
+test_that("writing a backed AnnData materializes its DelayedMatrix slots", {
+  msg <- message_if_known(
+    backend = "backed",
+    slot = "X",
+    dtype = "delayed",
+    process = "write",
+    known_issues = known_issues
+  )
+  skip_if(!is.null(msg), message = msg)
+
+  filename <- system.file("extdata", "example.h5ad", package = "anndataR")
+  backed <- HDF5AnnData$new(filename, mode = "r", backed = TRUE)
+  withr::defer(backed$close())
+
+  out <- withr::local_file(tempfile(fileext = ".h5ad"))
+  expect_no_error(write_h5ad(backed, out))
+
+  roundtrip <- HDF5AnnData$new(out, mode = "r")
+  withr::defer(roundtrip$close())
+  expect_false(inherits(roundtrip$X, "DelayedArray"))
+  expect_equal(as.matrix(roundtrip$X), as.matrix(backed$X))
 })

--- a/tests/testthat/test-HDF5File.R
+++ b/tests/testthat/test-HDF5File.R
@@ -21,6 +21,10 @@ test_that("opening an open HDF5File works", {
 })
 
 test_that("opening an HDF5File in read-only mode works", {
+  # Close first: open(readonly = TRUE) reuses an already-open read/write handle
+  # (a read/write handle can serve reads), so a fresh open is needed to get a
+  # genuinely read-only handle.
+  h5file$close()
   h5file$open(readonly = TRUE)
   expect_true(h5file$is_open)
   expect_true(h5file$is_readonly)


### PR DESCRIPTION
**Related to:** <!-- Add links to related issues etc. here -->

## Description

This PR aims to solve several issues in #387 ;

- Partially fixes performance regression: eager reads using HDF5Array seems to be quite a bit slower than native rhdf5 reads (110 alerts). the proposed changes bring it down to 10 alerts.
- anndataview now correctly subsets DelayedArrays instead of keeping them as is.
- When converting a backed HDFAnnData to InMemoryAnnData, DeferredArrays are materialised
- DelayedArrays are materialised on write. I don't think there is a way around this in HDF5AnnData.
- Fixed DelayedMatrix getting transposed on SCE roundtrip (cfr. Louise's comment)

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
