### PR TITLE
Fix `create_zarr()` so that Zarr stores can be created at relative paths

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # anndata 1.3.0
 
 - Bioconductor 3.24 devel
+- Fix `create_zarr()` so that Zarr stores can be created at relative paths and at paths containing regex metacharacters (PR #478).
 
 # anndataR 1.2.0
 

--- a/R/Rarr_utils.R
+++ b/R/Rarr_utils.R
@@ -57,9 +57,11 @@ create_zarr_group <- function(store, name, version = "v2") {
 #'
 #' @noRd
 create_zarr <- function(store, version = "v2") {
-  prefix <- basename(store)
-  dir <- gsub(paste0(prefix, "$"), "", store)
-  create_zarr_group(store = dir, name = prefix, version = version)
+  create_zarr_group(
+    store = dirname(store),
+    name = basename(store),
+    version = version
+  )
 }
 
 #' is_zarr_empty

--- a/tests/testthat/test-Zarr-write.R
+++ b/tests/testthat/test-Zarr-write.R
@@ -7,6 +7,22 @@ if (dir.exists(store)) {
 
 create_zarr(store = store)
 
+test_that("Creating a Zarr store at a relative path works", {
+  withr::with_tempdir({
+    create_zarr(store = "relative.zarr")
+    expect_true(dir.exists("relative.zarr"))
+    expect_true(file.exists(file.path("relative.zarr", ".zgroup")))
+  })
+})
+
+test_that("Creating a Zarr store with regex characters in the name works", {
+  store_regex <- tempfile(pattern = "a+b", fileext = ".zarr")
+  create_zarr(store = store_regex)
+  expect_true(file.exists(file.path(store_regex, ".zgroup")))
+  # The store must not be nested inside a directory of the same name
+  expect_false(dir.exists(file.path(store_regex, basename(store_regex))))
+})
+
 test_that("Writing Zarr dense arrays works", {
   array <- matrix(rnorm(20), nrow = 5, ncol = 4)
 


### PR DESCRIPTION
## Description

Small fix to `create_zarr` internal that safely creates a store using `dirname` instead of `gsub`, otherwise creating a store in the way directory, e.g. `create_zarr("temp.zarr")`, fails. 

## Checklist

**Before review**

- [x] Update and regenerate man pages (no need)
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
