### PR TITLE
Simplify roxygen docs

### DIFF
--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -1,32 +1,3 @@
-#' Read H5AD encoding
-#'
-#' Read the encoding and version of an element in a H5AD file
-#'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#'
-#' @return A named list with names type and version
-#'
-#' @noRd
-read_h5ad_encoding <- function(hdf5_file, name) {
-  hdf5_file$open_and_defer_close(readonly = TRUE)
-
-  tryCatch(
-    {
-      attrs <- rhdf5::h5readAttributes(hdf5_file$handle, name)
-      list(
-        type = attrs[["encoding-type"]],
-        version = attrs[["encoding-version"]]
-      )
-    },
-    error = function(e) {
-      cli_abort(
-        "Encoding attributes not found for element {.val {name}} in {.path {hdf5_file$path}}"
-      )
-    }
-  )
-}
-
 #' Read H5AD element
 #'
 #' Read an element from a H5AD file
@@ -114,12 +85,7 @@ read_h5ad_element <- function(
 #'
 #' Read the keys of an element from a H5AD file
 #'
-#' @param file Path to a H5AD file or an open H5AD handle
-#' @param name Name of the element within the H5AD file
-#' @param type The encoding type of the element to read
-#' @param version The encoding version of the element to read
-#' @param stop_on_error Whether to stop on error or generate a warning instead
-#' @param ... Extra arguments passed to individual reading functions
+#' @inheritParams read_h5ad_element
 #'
 #' @details
 #' Encoding is automatically determined from the element using
@@ -178,6 +144,34 @@ read_h5ad_element_keys <- function(
   )
 }
 
+#' Read H5AD encoding
+#'
+#' Read the encoding and version of an element in a H5AD file
+#'
+#' @inheritParams read_h5ad_element
+#'
+#' @return A named list with names type and version
+#'
+#' @noRd
+read_h5ad_encoding <- function(hdf5_file, name) {
+  hdf5_file$open_and_defer_close(readonly = TRUE)
+
+  tryCatch(
+    {
+      attrs <- rhdf5::h5readAttributes(hdf5_file$handle, name)
+      list(
+        type = attrs[["encoding-type"]],
+        version = attrs[["encoding-version"]]
+      )
+    },
+    error = function(e) {
+      cli_abort(
+        "Encoding attributes not found for element {.val {name}} in {.path {hdf5_file$path}}"
+      )
+    }
+  )
+}
+
 #' Read H5AD null
 #'
 #' Read a null value from an H5AD file
@@ -199,11 +193,7 @@ read_h5ad_null <- function(hdf5_file, name, version = "0.1.0", ...) {
 #'
 #' Read a dense array from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param backed Whether to return a DelayedArray
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a matrix/array or a DelayedArray if `backed = TRUE`
 #'
@@ -249,10 +239,7 @@ read_h5ad_dense_array <- function(
 #'
 #' Read a dense array from an H5AD file using base {rhdf5}
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a matrix/array
 #'
@@ -313,12 +300,7 @@ read_h5ad_csc_matrix <- function(hdf5_file, name, version, backed, ...) {
 #'
 #' Read a sparse array from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param backed Whether to return a DelayedArray
-#' @param version Encoding version of the element to read
-#' @param type Type of the sparse matrix, either "csr_matrix" or "csc_matrix"
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a sparse matrix/array or a DelayedArray if `backed = TRUE`
 #' @importFrom Matrix sparseMatrix
@@ -348,11 +330,8 @@ read_h5ad_sparse_array <- function(
 #'
 #' Read a sparse array from an H5AD file using base {rhdf5}
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
+#' @inheritParams read_h5ad_element
 #' @param type Type of the sparse matrix, either "csr_matrix" or "csc_matrix"
-#' @param ... Extra arguments for other reading functions (not used)
 #'
 #' @return a sparse matrix
 #' @importFrom Matrix sparseMatrix
@@ -387,10 +366,7 @@ read_h5ad_sparse_array_base <- function(
 #'
 #' Read a recarray from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @details
 #' A "record array" (recarray) is a Python NumPy array type that contains
@@ -421,10 +397,7 @@ read_h5ad_rec_array <- function(hdf5_file, name, version = "0.2.0", ...) {
 #'
 #' Read a nullable boolean from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a boolean vector
 #'
@@ -442,10 +415,7 @@ read_h5ad_nullable_boolean <- function(
 #'
 #' Read a nullable integer from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return an integer vector
 #'
@@ -463,10 +433,7 @@ read_h5ad_nullable_integer <- function(
 #'
 #' Read a nullable vector (boolean or integer) from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a nullable vector
 #'
@@ -491,10 +458,7 @@ read_h5ad_nullable <- function(hdf5_file, name, version = "0.1.0", ...) {
 #'
 #' Read a string array from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a character vector/matrix
 #'
@@ -525,10 +489,7 @@ read_h5ad_string_array <- function(hdf5_file, name, version = "0.2.0", ...) {
 #'
 #' Read a categorical from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a factor
 #'
@@ -560,10 +521,7 @@ read_h5ad_categorical <- function(hdf5_file, name, version = "0.2.0", ...) {
 #'
 #' Read a string scalar from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a character vector of length 1
 #'
@@ -580,10 +538,7 @@ read_h5ad_string_scalar <- function(hdf5_file, name, version = "0.2.0", ...) {
 #'
 #' Read a numeric scalar from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param ... Extra arguments for other reading functions (not used)
+#' @inheritParams read_h5ad_element
 #'
 #' @return a numeric vector of length 1
 #'
@@ -606,11 +561,7 @@ read_h5ad_numeric_scalar <- function(hdf5_file, name, version = "0.2.0", ...) {
 #'
 #' Read a mapping from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
-#' @param backed Whether to return DelayedArrays for array/matrix types
-#' @param ... Extra arguments for other reading functions
+#' @inheritParams read_h5ad_element
 #'
 #' @return a named list
 #'
@@ -633,9 +584,7 @@ read_h5ad_mapping <- function(
 #'
 #' Read keys for a mapping from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
+#' @inheritParams read_h5ad_element
 #'
 #' @return a character vector
 #'
@@ -655,12 +604,9 @@ read_h5ad_mapping_keys <- function(hdf5_file, name, version = "0.1.0") {
 #'
 #' Read a data frame from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
+#' @inheritParams read_h5ad_element
 #' @param backed Whether to return DelayedArrays for array/matrix types (always
 #' `FALSE`)
-#' @param ... Extra arguments for other reading functions
 #'
 #' @details
 #' The `backed` argument is included to avoid `backed` being passed via `...`
@@ -694,9 +640,7 @@ read_h5ad_data_frame <- function(
 #'
 #' Read keys for a data frame from an H5AD file
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param version Encoding version of the element to read
+#' @inheritParams read_h5ad_element
 #' @param dim Dimension to read keys for, either "both, "rows" or "cols"
 #'
 #' @return a character vector if dim is "rows" or "cols", or a list with
@@ -735,11 +679,8 @@ read_h5ad_data_frame_keys <- function(
 
 #' Read multiple H5AD datatypes
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
+#' @inheritParams read_h5ad_element
 #' @param item_names Vector of item names (in order)
-#' @param backed Whether to return DelayedArrays for array/matrix types
-#' @param ... Extra arguments for other reading functions
 #'
 #' @return a named list
 #'

--- a/R/read_h5ad_helpers.R
+++ b/R/read_h5ad_helpers.R
@@ -301,6 +301,7 @@ read_h5ad_csc_matrix <- function(hdf5_file, name, version, backed, ...) {
 #' Read a sparse array from an H5AD file
 #'
 #' @inheritParams read_h5ad_element
+#' @param type Type of the sparse matrix, either "csr_matrix" or "csc_matrix"
 #'
 #' @return a sparse matrix/array or a DelayedArray if `backed = TRUE`
 #' @importFrom Matrix sparseMatrix
@@ -331,7 +332,7 @@ read_h5ad_sparse_array <- function(
 #' Read a sparse array from an H5AD file using base {rhdf5}
 #'
 #' @inheritParams read_h5ad_element
-#' @param type Type of the sparse matrix, either "csr_matrix" or "csc_matrix"
+#' @inheritParams read_h5ad_sparse_array type
 #'
 #' @return a sparse matrix
 #' @importFrom Matrix sparseMatrix

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -1,30 +1,3 @@
-#' Read Zarr encoding
-#'
-#' Read the encoding and version of an element in a Zarr store
-#'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#'
-#' @return A named list with names type and version
-#'
-#' @noRd
-read_zarr_encoding <- function(store, name) {
-  tryCatch(
-    {
-      attrs <- Rarr::read_zarr_attributes(file.path(store, name))
-      list(
-        type = attrs[["encoding-type"]],
-        version = attrs[["encoding-version"]]
-      )
-    },
-    error = function(e) {
-      cli_abort(
-        "Encoding attributes not found for element {.val {name}} in {.path {store}}"
-      )
-    }
-  )
-}
-
 #' Read Zarr element
 #'
 #' Read an element from a Zarr store
@@ -102,13 +75,94 @@ read_zarr_element <- function(
   )
 }
 
+#' Read Zarr element keys
+#'
+#' Read the keys of an element from a Zarr store
+#'
+#' @inheritParams read_zarr_element
+#'
+#' @return A character vector of keys
+#'
+#' @noRd
+read_zarr_element_keys <- function(
+  store,
+  name,
+  type = NULL,
+  version = NULL,
+  stop_on_error = FALSE,
+  ...
+) {
+  if (!zarr_path_exists(store, name)) {
+    return(NULL)
+  }
+
+  if (is.null(type)) {
+    encoding_list <- read_zarr_encoding(store, name)
+    type <- encoding_list$type
+    version <- encoding_list$version
+  }
+
+  read_fun <- switch(
+    type,
+    "dataframe" = read_zarr_data_frame_keys,
+    "dict" = read_zarr_mapping_keys,
+    cli_abort(
+      "No function for reading keys for Zarr encoding {.cls {type}} for element {.val {name}}"
+    )
+  )
+
+  tryCatch(
+    {
+      read_fun(store = store, name = name, version = version, ...)
+    },
+    error = function(e) {
+      msg <- cli::cli_fmt(cli::cli_bullets(c(
+        paste0(
+          "Error reading element keys for {.field {name}} of type {.cls {type}}"
+        ),
+        "i" = conditionMessage(e)
+      )))
+      if (stop_on_error) {
+        cli_abort(msg)
+      } else {
+        cli_warn(msg)
+        NULL
+      }
+    }
+  )
+}
+
+#' Read Zarr encoding
+#'
+#' Read the encoding and version of an element in a Zarr store
+#'
+#' @inheritParams read_zarr_element
+#'
+#' @return A named list with names type and version
+#'
+#' @noRd
+read_zarr_encoding <- function(store, name) {
+  tryCatch(
+    {
+      attrs <- Rarr::read_zarr_attributes(file.path(store, name))
+      list(
+        type = attrs[["encoding-type"]],
+        version = attrs[["encoding-version"]]
+      )
+    },
+    error = function(e) {
+      cli_abort(
+        "Encoding attributes not found for element {.val {name}} in {.path {store}}"
+      )
+    }
+  )
+}
+
 #' Read Zarr null
 #'
 #' Read a null value from an Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return `NULL`
 #' @noRd
@@ -122,9 +176,7 @@ read_zarr_null <- function(store, name, version = "0.1.0") {
 #'
 #' Read a dense array from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return A matrix or a vector if 1D
 #'
@@ -159,9 +211,7 @@ read_zarr_csc_matrix <- function(store, name, version) {
 #'
 #' Read a sparse array from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #' @param type Type of the sparse matrix, either "csr_matrix" or "csc_matrix"
 #'
 #' @return A sparse matrix/DelayedArray???, or a vector if 1D
@@ -196,9 +246,7 @@ read_zarr_sparse_array <- function(
 #'
 #' Read a recarray from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @details
 #' A "record array" (recarray) is a Python NumPy array type that contains
@@ -221,9 +269,7 @@ read_zarr_rec_array <- function(store, name, version = "0.2.0") {
 #'
 #' Read a nullable boolean from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return A boolean vector
 #'
@@ -236,9 +282,7 @@ read_zarr_nullable_boolean <- function(store, name, version = "0.1.0") {
 #'
 #' Read a nullable integer from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return An integer vector
 #'
@@ -251,9 +295,7 @@ read_zarr_nullable_integer <- function(store, name, version = "0.1.0") {
 #'
 #' Read a nullable vector (boolean or integer) from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return A nullable vector
 #'
@@ -347,9 +389,7 @@ read_zarr_string_scalar <- function(store, name, version = "0.2.0") {
 #'
 #' Read a numeric scalar from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return A numeric vector of length 1
 #'
@@ -369,9 +409,7 @@ read_zarr_numeric_scalar <- function(store, name, version = "0.2.0") {
 #'
 #' Read a mapping from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return A named list
 #'
@@ -386,9 +424,7 @@ read_zarr_mapping <- function(store, name, version = "0.1.0") {
 #'
 #' Read a data frame from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return A data.frame
 #'
@@ -413,8 +449,7 @@ read_zarr_data_frame <- function(
 
 #' Read multiple Zarr datatypes
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
+#' @inheritParams read_zarr_element
 #' @param item_names Vector of item names (in order)
 #'
 #' @return A named list
@@ -438,75 +473,11 @@ read_zarr_collection <- function(store, name, item_names) {
   items
 }
 
-#' Read Zarr element keys
-#'
-#' Read the keys of an element from a Zarr store
-#'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param type The encoding type of the element to read
-#' @param version The encoding version of the element to read
-#' @param stop_on_error Whether to stop on error or generate a warning instead
-#' @param ... Extra arguments passed to individual reading functions
-#'
-#' @return A character vector of keys
-#'
-#' @noRd
-read_zarr_element_keys <- function(
-  store,
-  name,
-  type = NULL,
-  version = NULL,
-  stop_on_error = FALSE,
-  ...
-) {
-  if (!zarr_path_exists(store, name)) {
-    return(NULL)
-  }
-
-  if (is.null(type)) {
-    encoding_list <- read_zarr_encoding(store, name)
-    type <- encoding_list$type
-    version <- encoding_list$version
-  }
-
-  read_fun <- switch(
-    type,
-    "dataframe" = read_zarr_data_frame_keys,
-    "dict" = read_zarr_mapping_keys,
-    cli_abort(
-      "No function for reading keys for Zarr encoding {.cls {type}} for element {.val {name}}"
-    )
-  )
-
-  tryCatch(
-    {
-      read_fun(store = store, name = name, version = version, ...)
-    },
-    error = function(e) {
-      msg <- cli::cli_fmt(cli::cli_bullets(c(
-        paste0(
-          "Error reading element keys for {.field {name}} of type {.cls {type}}"
-        ),
-        "i" = conditionMessage(e)
-      )))
-      if (stop_on_error) {
-        cli_abort(msg)
-      } else {
-        cli_warn(msg)
-        NULL
-      }
-    }
-  )
-}
-
 #' Read Zarr mapping keys
 #'
 #' Read keys for a mapping (dict) from a Zarr store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #'
 #' @return A character vector of item names
 #'
@@ -527,9 +498,7 @@ read_zarr_mapping_keys <- function(store, name, version = "0.1.0") {
 #' Read the row names (index) and/or column names of a data frame from a Zarr
 #' store
 #'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param version Encoding version of the element to read
+#' @inheritParams read_zarr_element
 #' @param dim Dimension to read keys for: `"both"`, `"rows"`, or `"cols"`
 #'
 #' @return A character vector if `dim` is `"rows"` or `"cols"`, or a list with

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -7,7 +7,7 @@
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' #' @param stop_on_error Whether to stop on error or generate a warning instead
+#' @param stop_on_error Whether to stop on error or generate a warning instead
 #' @param ... Additional arguments passed to writing functions
 #'
 #' @noRd
@@ -132,8 +132,7 @@ write_h5ad_element <- function(
 #'
 #' @noRd
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
+#' @inheritParams write_h5ad_element
 #' @param encoding The encoding type to set
 #' @param version The encoding version to set
 write_h5ad_encoding <- function(hdf5_file, name, encoding, version) {
@@ -160,11 +159,8 @@ write_h5ad_encoding <- function(hdf5_file, name, encoding, version) {
 #'
 #' Write a null dataset to an H5AD file
 #'
-#' @param value Value to write, not used
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression Not used as there is no value
-#' @param version Encoding version of the element to write
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
 #' @noRd
 write_h5ad_null <- function(
@@ -198,12 +194,8 @@ write_h5ad_null <- function(
 #'
 #' Write a dense array to an H5AD file
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
 #' @noRd
 write_h5ad_dense_array <- function(
@@ -268,14 +260,10 @@ write_h5ad_dense_array <- function(
 #'
 #' Write a sparse array to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_h5ad_sparse_array <- function(
   value,
   hdf5_file,
@@ -347,14 +335,10 @@ write_h5ad_sparse_array <- function(
 #'
 #' Write a nullable boolean to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 # nolint start: object_length_linter
 write_h5ad_nullable_boolean <- function(
   value,
@@ -396,14 +380,10 @@ write_h5ad_nullable_boolean <- function(
 #'
 #' Write a nullable integer to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 # nolint start: object_length_linter
 write_h5ad_nullable_integer <- function(
   value,
@@ -444,14 +424,10 @@ write_h5ad_nullable_integer <- function(
 #'
 #' Write a string array to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_h5ad_string_array <- function(
   value,
   hdf5_file,
@@ -485,14 +461,10 @@ write_h5ad_string_array <- function(
 #'
 #' Write a categorical to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_h5ad_categorical <- function(
   value,
   hdf5_file,
@@ -551,14 +523,10 @@ write_h5ad_categorical <- function(
 #'
 #' Write a string scalar to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_h5ad_string_scalar <- function(
   value,
   hdf5_file,
@@ -583,14 +551,10 @@ write_h5ad_string_scalar <- function(
 #'
 #' Write a numeric scalar to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_h5ad_numeric_scalar <- function(
   value,
   hdf5_file,
@@ -626,14 +590,10 @@ write_h5ad_numeric_scalar <- function(
 #'
 #' Write a mapping to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_h5ad_mapping <- function(
   value,
   hdf5_file,
@@ -664,17 +624,13 @@ write_h5ad_mapping <- function(
 #'
 #' Write a data frame to an H5AD file
 #'
-#' @noRd
-#'
-#' @param value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #' @param index The index to write. Can either be a vector of length equal to
 #' the number of rows in `values` or a single character string giving the name
 #' of a column in `values`. If `NULL` then `rownames(value)` is used.
-#' @param version Encoding version of the element to write
+#'
+#' @noRd
 write_h5ad_data_frame <- function(
   value,
   hdf5_file,
@@ -760,14 +716,10 @@ write_h5ad_data_frame <- function(
 #'
 #' Write a data frame index to an H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param index_value Value to write
-#' @param hdf5_file An `HDF5File` object
-#' @param name Name of the element within the H5AD file
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_h5ad_data_frame_index <- function(
   index_value,
   hdf5_file,
@@ -794,14 +746,10 @@ write_h5ad_data_frame_index <- function(
 #'
 #' Write a new empty H5AD file
 #'
-#' @noRd
+#' @inheritParams write_h5ad_element
+#' @inheritParams write_h5ad_encoding version
 #'
-#' @param hdf5_file An `HDF5File` object
-#' @param obs Data frame with observations
-#' @param var Data frame with variables
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version The H5AD version to write
+#' @noRd
 write_empty_h5ad <- function(
   hdf5_file,
   obs,

--- a/R/write_h5ad_helpers.R
+++ b/R/write_h5ad_helpers.R
@@ -7,6 +7,10 @@
 #' @param name Name of the element within the H5AD file
 #' @param compression The compression to use when writing the element. Can be
 #' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
+#' @param chunk_size Target chunk size in bytes. When `"auto"` (default), the
+#'   chunk size is determined automatically using `hdf5_auto_chunk()`.
+#'   When `NULL`, chunking is disabled (contiguous storage, the rhdf5 default).
+#'   When a number, it is used as the target chunk size in bytes.
 #' @param stop_on_error Whether to stop on error or generate a warning instead
 #' @param ... Additional arguments passed to writing functions
 #'

--- a/R/write_zarr_helpers.R
+++ b/R/write_zarr_helpers.R
@@ -5,8 +5,9 @@
 #' @param value The value to write
 #' @param store A Zarr store instance
 #' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"` or `"gzip"`. Defaults to `"none"`.
+#' @param compression The compression to use when writing the element. 
+#'   One of `"none"`, `"gzip"`, `"blosc"`, `"zstd"`, `"lzma"`, `"bz2"`, 
+#'   `"zlib"`, `"lz4"`.
 #' @param stop_on_error Whether to stop on error or generate a warning instead
 #' @param ... Additional arguments passed to writing functions
 #'
@@ -124,12 +125,11 @@ write_zarr_element <- function(
 #'
 #' Write Zarr encoding attributes to an element in a Zarr store
 #'
-#' @noRd
-#'
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
+#' @inheritParams write_zarr_element
 #' @param encoding The encoding type to set
 #' @param version The encoding version to set
+#'
+#' @noRd
 write_zarr_encoding <- function(store, name, encoding, version) {
   Rarr::write_zarr_attributes(
     file.path(store, name),
@@ -141,11 +141,8 @@ write_zarr_encoding <- function(store, name, encoding, version) {
 #'
 #' Write a null dataset to an Zarr file
 #'
-#' @param value Value to write, not used
-#' @param store An open Zarr handle
-#' @param name Name of the element within the Zarr store
-#' @param compression Not used as there is no value
-#' @param version Encoding version of the element to write
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
 #' @noRd
 write_zarr_null <- function(
@@ -174,14 +171,10 @@ write_zarr_null <- function(
 #'
 #' Write a dense array to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_dense_array <- function(
   value,
   store,
@@ -211,14 +204,10 @@ write_zarr_dense_array <- function(
 #'
 #' Write a sparse array to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_sparse_array <- function(
   value,
   store,
@@ -276,14 +265,10 @@ write_zarr_sparse_array <- function(
 #'
 #' Write a nullable boolean to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_nullable_boolean <- function(
   value,
   store,
@@ -317,14 +302,10 @@ write_zarr_nullable_boolean <- function(
 #'
 #' Write a nullable integer to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_nullable_integer <- function(
   value,
   store,
@@ -358,14 +339,10 @@ write_zarr_nullable_integer <- function(
 #'
 #' Write a string array to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_string_array <- function(
   value,
   store,
@@ -412,14 +389,10 @@ write_zarr_string_array <- function(
 #'
 #' Write a categorical to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_categorical <- function(
   value,
   store,
@@ -465,14 +438,10 @@ write_zarr_categorical <- function(
 #'
 #' Write a string scalar to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_string_scalar <- function(
   value,
   store,
@@ -498,14 +467,10 @@ write_zarr_string_scalar <- function(
 #'
 #' Write a numeric scalar to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_numeric_scalar <- function(
   value,
   store,
@@ -524,14 +489,10 @@ write_zarr_numeric_scalar <- function(
 #'
 #' Write a mapping to a Zarr store
 #'
-#' @noRd
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
-#' @param version Encoding version of the element to write
+#' @noRd
 write_zarr_mapping <- function(
   value,
   store,
@@ -558,17 +519,13 @@ write_zarr_mapping <- function(
 #'
 #' Write a data frame to a Zarr store
 #'
-#' @noRd
-#'
-#' @param value Value to write
-#' @param store A Zarr store instance
-#' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"`, `"gzip"` or `"lzf"`. Defaults to `"none"`.
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #' @param index The index to write. Can either be a vector of length equal to
 #' the number of rows in `values` or a single character string giving the name
 #' of a column in `values`. If `NULL` then `rownames(value)` is used.
-#' @param version Encoding version of the element to write
+#'
+#' @noRd
 write_zarr_data_frame <- function(
   value,
   store,
@@ -645,14 +602,12 @@ write_zarr_data_frame <- function(
 #'
 #' Write a new empty Zarr store
 #'
-#' @noRd
-#'
-#' @param store Path to the Zarr store to write
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #' @param obs Data frame with observations
 #' @param var Data frame with variables
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"` or `"gzip"`. Defaults to `"none"`.
-#' @param version The anndata on-disk format version to write
+#'
+#' @noRd
 write_empty_zarr <- function(
   store,
   obs,
@@ -689,17 +644,12 @@ write_empty_zarr <- function(
 #'
 #' Write Zarr dataset with chosen compression (can be none)
 #'
-#' @return  Returns (invisibly) `TRUE` if the array is successfully written.
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
 #' @noRd
 #'
-#' @param store Path to a Zarr store
-#' @param name Name of the element within the Zarr store containing the data
-#' frame
-#' @param value Value to write. Must be a vector to the same length as the data
-#' frame.
-#' @param compression The compression to use when writing the element. Can be
-#' one of `"none"` or `"gzip"`. Defaults to `"none"`.
+#' @return  Returns (invisibly) `TRUE` if the array is successfully written.
 zarr_write_compressed <- function(
   store,
   name,
@@ -722,12 +672,12 @@ zarr_write_compressed <- function(
 #'
 #' Convert a compression name to the corresponding Rarr compressor object.
 #'
-#' @param compression The compression algorithm name. One of `"none"`,
-#'   `"gzip"`, `"blosc"`, `"zstd"`, `"lzma"`, `"bz2"`, `"zlib"`, `"lz4"`.
-#'
-#' @return A Rarr compressor object, or `NULL` for no compression.
+#' @inheritParams write_zarr_element
+#' @inheritParams write_zarr_encoding version
 #'
 #' @noRd
+#'
+#' @return A Rarr compressor object, or `NULL` for no compression.
 .get_compressor <- function(compression) {
   switch(
     compression,

--- a/R/write_zarr_helpers.R
+++ b/R/write_zarr_helpers.R
@@ -5,8 +5,8 @@
 #' @param value The value to write
 #' @param store A Zarr store instance
 #' @param name Name of the element within the Zarr store
-#' @param compression The compression to use when writing the element. 
-#'   One of `"none"`, `"gzip"`, `"blosc"`, `"zstd"`, `"lzma"`, `"bz2"`, 
+#' @param compression The compression to use when writing the element.
+#'   One of `"none"`, `"gzip"`, `"blosc"`, `"zstd"`, `"lzma"`, `"bz2"`,
 #'   `"zlib"`, `"lz4"`.
 #' @param stop_on_error Whether to stop on error or generate a warning instead
 #' @param ... Additional arguments passed to writing functions


### PR DESCRIPTION
**Related to:** #455 and https://github.com/scverse/anndataR/pull/455#discussion_r3473328944

## Description

Based on @Bisaloo 's suggestion, using `@inheritParams` for h5ad/zarr helpers to avoid repetitive `@param` tags. For now, only applied to helper scripts, but could be performed elsewhere if needed. 

Another note is that, since these are internal functions and are not exported, `@inheritParams`, does not really help beyond telling devs where to look for argument descriptions, but helps avoiding errors. I have found many inconsistencies while replacing with `@inheritParams` tag.  

## Checklist

**Before review**

- [x] Update and regenerate man pages
- [x] Add/update tests (no need)
- [x] Add/update examples in vignettes (no need)
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version