### PR TITLE
Require Python `anndata<0.13.0` in tests

### DIFF
--- a/.github/workflows/R-CMD-check-bioc.yaml
+++ b/.github/workflows/R-CMD-check-bioc.yaml
@@ -91,6 +91,8 @@ jobs:
         shell: Rscript {0}
         run: |
           reticulate::install_miniconda()
+          # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+          # supports Python anndata >= 0.13.0
           reticulate::py_install(
             c("scanpy", "mudata", "anndata<0.13.0"),
             method = "conda",

--- a/.github/workflows/R-CMD-check-bioc.yaml
+++ b/.github/workflows/R-CMD-check-bioc.yaml
@@ -92,7 +92,7 @@ jobs:
         run: |
           reticulate::install_miniconda()
           reticulate::py_install(
-            c("scanpy", "mudata"),
+            c("scanpy", "mudata", "anndata<0.13.0"),
             method = "conda",
             channel = "conda-forge"
           )

--- a/.github/workflows/bench-base.yaml
+++ b/.github/workflows/bench-base.yaml
@@ -47,7 +47,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python dependencies
-        run: pip install anndata dummy-anndata
+        run: pip install "anndata<0.13.0" dummy-anndata
 
       - name: Configure reticulate
         run: echo "RETICULATE_PYTHON=$(which python)" >> $GITHUB_ENV

--- a/.github/workflows/bench-base.yaml
+++ b/.github/workflows/bench-base.yaml
@@ -47,6 +47,8 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python dependencies
+        # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+        # supports Python anndata >= 0.13.0
         run: pip install "anndata<0.13.0" dummy-anndata
 
       - name: Configure reticulate

--- a/.github/workflows/bench-pr-run.yaml
+++ b/.github/workflows/bench-pr-run.yaml
@@ -45,6 +45,8 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python dependencies
+        # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+        # supports Python anndata >= 0.13.0
         run: pip install "anndata<0.13.0" dummy-anndata
 
       - name: Configure reticulate

--- a/.github/workflows/bench-pr-run.yaml
+++ b/.github/workflows/bench-pr-run.yaml
@@ -45,7 +45,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python dependencies
-        run: pip install anndata dummy-anndata
+        run: pip install "anndata<0.13.0" dummy-anndata
 
       - name: Configure reticulate
         run: echo "RETICULATE_PYTHON=$(which python)" >> $GITHUB_ENV

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Configure python dependencies and reticulate
         run: |
-          pip install scanpy mudata
+          pip install "anndata<0.13.0" scanpy mudata
           echo "RETICULATE_PYTHON=$(which python3)" >> ~/.Renviron
           echo "Python configured for reticulate:" && Rscript -e 'reticulate::py_config()'
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Configure python dependencies and reticulate
         run: |
+          # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+          # supports Python anndata >= 0.13.0
           pip install "anndata<0.13.0" scanpy mudata
           echo "RETICULATE_PYTHON=$(which python3)" >> ~/.Renviron
           echo "Python configured for reticulate:" && Rscript -e 'reticulate::py_config()'

--- a/tests/testthat/helper-skip_if_no_anndata_py.R
+++ b/tests/testthat/helper-skip_if_no_anndata_py.R
@@ -2,6 +2,8 @@
 skip_if_no_anndata_py <- function() {
   testthat::skip_if_not_installed("reticulate")
   requireNamespace("reticulate")
+  # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR supports
+  # Python anndata >= 0.13.0
   reticulate::py_require("anndata<0.13.0")
   testthat::skip_if_not(
     reticulate::py_module_available("anndata"),

--- a/tests/testthat/helper-skip_if_no_anndata_py.R
+++ b/tests/testthat/helper-skip_if_no_anndata_py.R
@@ -2,7 +2,7 @@
 skip_if_no_anndata_py <- function() {
   testthat::skip_if_not_installed("reticulate")
   requireNamespace("reticulate")
-  reticulate::py_require("anndata")
+  reticulate::py_require("anndata<0.13.0")
   testthat::skip_if_not(
     reticulate::py_module_available("anndata"),
     message = "Python anndata module not available for testing"

--- a/vignettes/usage_python.Rmd
+++ b/vignettes/usage_python.Rmd
@@ -12,6 +12,7 @@ vignette: >
 # Set up reticulate and check for required Python packages.
 reticulate::py_require("mudata")
 reticulate::py_require("scanpy")
+reticulate::py_require("anndata<0.13.0")
 
 # Check if required Python packages are available.
 python_available <- reticulate::py_module_available("scanpy") &&
@@ -58,6 +59,7 @@ Install required Python packages if needed:
 
 ```{r python_setup, eval=FALSE}
 reticulate::py_require("scanpy")
+reticulate::py_require("anndata<0.13.0")
 ```
 
 ```{r load_libraries}

--- a/vignettes/usage_python.Rmd
+++ b/vignettes/usage_python.Rmd
@@ -11,7 +11,7 @@ vignette: >
 ```{r, include = FALSE}
 # Set up reticulate and check for required Python packages.
 reticulate::py_require("mudata")
-reticulate::py_require("scanpy")
+reticulate::py_require("scanpy>=1.10")
 reticulate::py_require("anndata<0.13.0")
 
 # Check if required Python packages are available.
@@ -58,7 +58,7 @@ If these are not available, the code chunks will not be evaluated but the exampl
 Install required Python packages if needed:
 
 ```{r python_setup, eval=FALSE}
-reticulate::py_require("scanpy")
+reticulate::py_require("scanpy>=1.10")
 reticulate::py_require("anndata<0.13.0")
 ```
 

--- a/vignettes/usage_python.Rmd
+++ b/vignettes/usage_python.Rmd
@@ -11,6 +11,8 @@ vignette: >
 ```{r, include = FALSE}
 # Set up reticulate and check for required Python packages.
 reticulate::py_require("mudata")
+# TEMP(anndata<0.13.0): pin and the scanpy lower bound were added in PR #481,
+# revert once anndataR supports Python anndata >= 0.13.0
 reticulate::py_require("scanpy>=1.10")
 reticulate::py_require("anndata<0.13.0")
 
@@ -58,6 +60,7 @@ If these are not available, the code chunks will not be evaluated but the exampl
 Install required Python packages if needed:
 
 ```{r python_setup, eval=FALSE}
+# TEMP(anndata<0.13.0): anndataR does not yet support Python anndata >= 0.13.0
 reticulate::py_require("scanpy>=1.10")
 reticulate::py_require("anndata<0.13.0")
 ```


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. Use dot points or a check list if needed -->

As a temporary fix for everything failing pin the previous version of Python **anndata** in tests

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
