### PR TITLE
Avoid copy when dropping attributes

### DIFF
--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -47,8 +47,8 @@ read_zarr_element <- function(
     "numeric-scalar" = read_zarr_numeric_scalar,
     "categorical" = read_zarr_categorical,
     "string-array" = read_zarr_string_array,
-    "nullable-integer" = read_zarr_nullable_integer,
-    "nullable-boolean" = read_zarr_nullable_boolean,
+    "nullable-integer" = read_zarr_nullable,
+    "nullable-boolean" = read_zarr_nullable,
     cli_abort(
       "No function for reading Zarr encoding {.cls {type}} for element {.val {name}}"
     )
@@ -263,32 +263,6 @@ read_zarr_rec_array <- function(store, name, version = "0.2.0") {
   version <- match.arg(version)
   Rarr::read_zarr_array(file.path(store, name)) |>
     lapply(as.vector)
-}
-
-#' Read Zarr nullable boolean
-#'
-#' Read a nullable boolean from a Zarr store
-#'
-#' @inheritParams read_zarr_element
-#'
-#' @return A boolean vector
-#'
-#' @noRd
-read_zarr_nullable_boolean <- function(store, name, version = "0.1.0") {
-  as.logical(read_zarr_nullable(store, name, version))
-}
-
-#' Read Zarr nullable integer
-#'
-#' Read a nullable integer from a Zarr store
-#'
-#' @inheritParams read_zarr_element
-#'
-#' @return An integer vector
-#'
-#' @noRd
-read_zarr_nullable_integer <- function(store, name, version = "0.1.0") {
-  as.integer(read_zarr_nullable(store, name, version))
 }
 
 #' Read Zarr nullable

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -431,8 +431,8 @@ read_zarr_data_frame <- function(
 #' @noRd
 read_zarr_collection <- function(store, name, item_names) {
   items <- lapply(
-    item_names,
-    function(item_name) {
+    file.path(name, item_names),
+    function(new_name) {
       new_name <- paste0(name, "/", item_name)
       encoding <- read_zarr_encoding(store, new_name)
       read_zarr_element(

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -229,15 +229,18 @@ read_zarr_sparse_array <- function(
 
   attrs <- Rarr::read_zarr_attributes(file.path(store, name))
 
+  data <- Rarr::read_zarr_array(file.path(store, name, "data"))
+  dim(data) <- NULL
+  indices <- Rarr::read_zarr_array(file.path(store, name, "indices"))
+  dim(indices) <- NULL
+  indptr <- Rarr::read_zarr_array(file.path(store, name, "indptr"))
+  dim(indptr) <- NULL
+
   construct_sparse_matrix(
-    data = as.vector(Rarr::read_zarr_array(file.path(store, name, "data"))),
-    indices = as.vector(Rarr::read_zarr_array(file.path(
-      store,
-      name,
-      "indices"
-    ))),
-    indptr = as.vector(Rarr::read_zarr_array(file.path(store, name, "indptr"))),
-    shape = as.vector(unlist(attrs$shape, use.names = FALSE)),
+    data = data,
+    indices = indices,
+    indptr = indptr,
+    shape = unlist(attrs$shape, use.names = FALSE),
     type = type
   )
 }
@@ -262,7 +265,10 @@ read_zarr_sparse_array <- function(
 read_zarr_rec_array <- function(store, name, version = "0.2.0") {
   version <- match.arg(version)
   Rarr::read_zarr_array(file.path(store, name)) |>
-    lapply(as.vector)
+    lapply(\(el) {
+      dim(el) <- NULL
+      el
+    })
 }
 
 #' Read Zarr nullable
@@ -283,6 +289,8 @@ read_zarr_nullable <- function(store, name, version = "0.1.0") {
   # Get values and set missing
   element <- values
   element[mask] <- NA
+
+  dim(element) <- NULL
 
   element
 }
@@ -356,7 +364,9 @@ read_zarr_categorical <- function(store, name, version = "0.2.0") {
 #' @noRd
 read_zarr_string_scalar <- function(store, name, version = "0.2.0") {
   version <- match.arg(version)
-  as.character(Rarr::read_zarr_array(file.path(store, name)))
+  res <- Rarr::read_zarr_array(file.path(store, name))
+  dim(res) <- NULL
+  res
 }
 
 #' Read Zarr numeric scalar
@@ -374,7 +384,7 @@ read_zarr_numeric_scalar <- function(store, name, version = "0.2.0") {
   value <- Rarr::read_zarr_array(file.path(store, name))
 
   # convert array to vector
-  value <- as.vector(value)
+  dim(value) <- NULL
 
   value
 }
@@ -433,7 +443,6 @@ read_zarr_collection <- function(store, name, item_names) {
   items <- lapply(
     file.path(name, item_names),
     function(new_name) {
-      new_name <- paste0(name, "/", item_name)
       encoding <- read_zarr_encoding(store, new_name)
       read_zarr_element(
         store = store,
@@ -493,12 +502,16 @@ read_zarr_data_frame_keys <- function(
   column_order <- attrs[["column-order"]]
 
   if (dim == "both") {
+    rows <- read_zarr_element(store, file.path(name, index_name))
+    dim(rows) <- NULL
     list(
-      rows = as.vector(read_zarr_element(store, file.path(name, index_name))),
+      rows = rows,
       cols = as.character(column_order)
     )
   } else if (dim == "rows") {
-    as.vector(read_zarr_element(store, file.path(name, index_name)))
+    rows <- read_zarr_element(store, file.path(name, index_name))
+    dim(rows) <- NULL
+    rows
   } else if (dim == "cols") {
     as.character(column_order)
   }

--- a/tests/testthat/test-Zarr-read.R
+++ b/tests/testthat/test-Zarr-read.R
@@ -84,7 +84,7 @@ for (zarr_version in c("v2", "v3")) {
   )
 
   test_that(paste("reading Zarr", zarr_version, "1D nullable arrays works"), {
-    array_1d <- read_zarr_nullable_integer(store, "obs/IntNA")
+    array_1d <- read_zarr_nullable(store, "obs/IntNA")
     expect_vector(array_1d, ptype = integer(), size = 50)
     expect_true(anyNA(array_1d))
 
@@ -93,7 +93,7 @@ for (zarr_version in c("v2", "v3")) {
     expected[1] <- NA
     expect_equal(array_1d, expected)
 
-    array_1d <- read_zarr_nullable_boolean(store, "obs/BoolNA")
+    array_1d <- read_zarr_nullable(store, "obs/BoolNA")
     expect_vector(array_1d, ptype = logical(), size = 50)
     expect_true(anyNA(array_1d))
   })

--- a/tests/testthat/test-h5ad-zarr.R
+++ b/tests/testthat/test-h5ad-zarr.R
@@ -96,7 +96,7 @@ test_that("reading 1D sparse numeric arrays is the same for h5ad and zarr", {
 test_that("reading 1D nullable arrays is the same for h5ad and zarr", {
   expect_equal_h5ad_zarr(
     read_h5ad_nullable_integer,
-    read_zarr_nullable_integer,
+    read_zarr_nullable,
     "obs/IntNA"
   )
   expect_equal_h5ad_zarr(
@@ -107,7 +107,7 @@ test_that("reading 1D nullable arrays is the same for h5ad and zarr", {
   for (path in c("obs/Bool", "obs/BoolNA")) {
     expect_equal_h5ad_zarr(
       read_h5ad_nullable_boolean,
-      read_zarr_nullable_boolean,
+      read_zarr_nullable,
       path
     )
   }


### PR DESCRIPTION
## Description

I may be missing something so mostly opening this for discussion for now.

In many cases, it seems anndataR wants a vector instead of an array with a single dimension. In the current code, this is usually achieved via `as.vector()` / `as.integer()` / etc.

But this is very inefficient because it results in a entire new copy of the object in memory.

Would it work for you to drop the `dim` attribute? In your use case, it should not result in an additional copy of the data.

``` r
x <- sample(1:1e7, 1e7, replace = TRUE)
dim(x) <- 1e7

bench::mark(
  as.vector(x),
  as.integer(x),
  # We assign to y here for benchmarking purposes. To avoid removing dim for our test object after the first iteration.
  { 
    y <- x
    dim(y) <- NULL
    y
  },
  iterations = 1000
)
#> # A tibble: 3 × 6
#>   expression                       min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>                  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 as.vector(x)                  11.5ms   12.3ms      81.3    38.1MB     25.3
#> 2 as.integer(x)                 11.5ms   12.3ms      81.2    38.1MB     20.3
#> 3 { y <- x dim(y) <- NULL y }    326ns    359ns 2545301.         0B      0
```

<sup>Created on 2026-07-20 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I took a reasonably large test dataset but note that this get much worse with larger datasets, while remove `dim` always remains free, independent of the dataset size.

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
