### PR TITLE
Backport fixes to Bioc 3.23 - anndataR 1.2.1

### DIFF
--- a/.github/workflows/R-CMD-check-bioc.yaml
+++ b/.github/workflows/R-CMD-check-bioc.yaml
@@ -123,8 +123,10 @@ jobs:
         shell: Rscript {0}
         run: |
           reticulate::install_miniconda()
+          # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+          # supports Python anndata >= 0.13.0
           reticulate::py_install(
-            c("scanpy", "mudata"),
+            c("scanpy", "mudata", "anndata<0.13.0"),
             method = "conda",
             channel = "conda-forge"
           )

--- a/.github/workflows/bench-base.yaml
+++ b/.github/workflows/bench-base.yaml
@@ -47,7 +47,9 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python dependencies
-        run: pip install anndata dummy-anndata
+        # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+        # supports Python anndata >= 0.13.0
+        run: pip install "anndata<0.13.0" dummy-anndata
 
       - name: Configure reticulate
         run: echo "RETICULATE_PYTHON=$(which python)" >> $GITHUB_ENV

--- a/.github/workflows/bench-pr-run.yaml
+++ b/.github/workflows/bench-pr-run.yaml
@@ -45,7 +45,9 @@ jobs:
           python-version: '3.x'
 
       - name: Install Python dependencies
-        run: pip install anndata dummy-anndata
+        # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+        # supports Python anndata >= 0.13.0
+        run: pip install "anndata<0.13.0" dummy-anndata
 
       - name: Configure reticulate
         run: echo "RETICULATE_PYTHON=$(which python)" >> $GITHUB_ENV

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -49,7 +49,9 @@ jobs:
 
       - name: Configure python dependencies and reticulate
         run: |
-          pip install scanpy mudata
+          # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
+          # supports Python anndata >= 0.13.0
+          pip install "anndata<0.13.0" scanpy mudata
           echo "RETICULATE_PYTHON=$(which python3)" >> ~/.Renviron
           echo "Python configured for reticulate:" && Rscript -e 'reticulate::py_config()'
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: anndataR
 Title: AnnData interoperability in R
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: c(
     person("Robrecht", "Cannoodt", , "rcannood@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-3641-729X", github = "rcannood")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # anndataR 1.2.1
 
+Backported from the development branch (PR #489):
+
 - Fix `create_zarr()` so that Zarr stores can be created at relative paths and at paths containing regex metacharacters (PR #478).
+- Fix conditional expression in `AbstractAnnData` matrix validation (PR #487).
+- Require Python `anndata<0.13.0` in tests, workflows and vignettes (PR #481).
+- Update `CITATION` with the published paper (PR #464).
 
 # anndataR 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# anndataR 1.2.1
+
+- Fix `create_zarr()` so that Zarr stores can be created at relative paths and at paths containing regex metacharacters (PR #478).
+
+# anndataR 1.2.0
+
+- Bioconductor 3.23 release
+
 # anndataR 1.1.3
 
 - Prepare for Bioconductor 3.23 release (PR #449).

--- a/R/AbstractAnnData.R
+++ b/R/AbstractAnnData.R
@@ -448,7 +448,7 @@ AbstractAnnData <- R6::R6Class(
         rownames(mat) <- NULL
       }
 
-      if (!is.null(expected_colnames) & !is.null(colnames(mat))) {
+      if (!is.null(expected_colnames) && !is.null(colnames(mat))) {
         if (!identical(colnames(mat), expected_colnames)) {
           cli_abort(
             c(

--- a/R/Rarr_utils.R
+++ b/R/Rarr_utils.R
@@ -57,9 +57,11 @@ create_zarr_group <- function(store, name, version = "v2") {
 #'
 #' @noRd
 create_zarr <- function(store, version = "v2") {
-  prefix <- basename(store)
-  dir <- gsub(paste0(prefix, "$"), "", store)
-  create_zarr_group(store = dir, name = prefix, version = version)
+  create_zarr_group(
+    store = dirname(store),
+    name = basename(store),
+    version = version
+  )
 }
 
 #' is_zarr_empty

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,13 +1,23 @@
 bibentry(
   bibtype = "Article",
-  title = "{anndataR} improves interoperability between R and Python in single-cell transcriptomics",
+  title = "anndataR improves interoperability between R and Python in single-cell transcriptomics",
   author = c(
-    as.person("Louise Deconinck, Luke Zappia, Robrecht Cannoodt, Martin Morgan"),
-    person(given = "scverse core"),
-    as.person("Isaac Virshup, Chananchida Sang-aram, Danila Bredikhin, Ruth Seurinck, Yvan Saeys")
+    as.person("Louise Deconinck"),
+    as.person("Luke Zappia"),
+    as.person("Robrecht Cannoodt"),
+    as.person("Martin Morgan"),
+    as.person("Isaac Virshup"),
+    as.person("Chananchida Sang-aram"), 
+    as.person("Danila Bredikhin"), 
+    as.person("Ruth Seurinck"), 
+    as.person("Yvan Saeys"),
+    person(given = "scverse core")
   ),
-  journal = "bioRxiv",
-  year = 2025,
-  pages = "2025.08.18.669052",
-  doi = "10.1101/2025.08.18.669052"
+  journal = "Bioinformatics",
+  volume = 42,
+  issue = 6,
+  month = "June",
+  year = 2026,
+  pages = "btag288",
+  doi = "10.1093/bioinformatics/btag288"
 )

--- a/tests/testthat/helper-skip_if_no_anndata_py.R
+++ b/tests/testthat/helper-skip_if_no_anndata_py.R
@@ -2,7 +2,9 @@
 skip_if_no_anndata_py <- function() {
   testthat::skip_if_not_installed("reticulate")
   requireNamespace("reticulate")
-  reticulate::py_require("anndata")
+  # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR supports
+  # Python anndata >= 0.13.0
+  reticulate::py_require("anndata<0.13.0")
   testthat::skip_if_not(
     reticulate::py_module_available("anndata"),
     message = "Python anndata module not available for testing"

--- a/tests/testthat/test-Zarr-write.R
+++ b/tests/testthat/test-Zarr-write.R
@@ -7,6 +7,22 @@ if (dir.exists(store)) {
 
 create_zarr(store = store)
 
+test_that("Creating a Zarr store at a relative path works", {
+  withr::with_tempdir({
+    create_zarr(store = "relative.zarr")
+    expect_true(dir.exists("relative.zarr"))
+    expect_true(file.exists(file.path("relative.zarr", ".zgroup")))
+  })
+})
+
+test_that("Creating a Zarr store with regex characters in the name works", {
+  store_regex <- tempfile(pattern = "a+b", fileext = ".zarr")
+  create_zarr(store = store_regex)
+  expect_true(file.exists(file.path(store_regex, ".zgroup")))
+  # The store must not be nested inside a directory of the same name
+  expect_false(dir.exists(file.path(store_regex, basename(store_regex))))
+})
+
 test_that("Writing Zarr dense arrays works", {
   array <- matrix(rnorm(20), nrow = 5, ncol = 4)
 

--- a/vignettes/usage_python.Rmd
+++ b/vignettes/usage_python.Rmd
@@ -11,7 +11,10 @@ vignette: >
 ```{r, include = FALSE}
 # Set up reticulate and check for required Python packages.
 reticulate::py_require("mudata")
-reticulate::py_require("scanpy")
+# TEMP(anndata<0.13.0): pin and the scanpy lower bound were added in PR #481,
+# revert once anndataR supports Python anndata >= 0.13.0
+reticulate::py_require("scanpy>=1.10")
+reticulate::py_require("anndata<0.13.0")
 
 # Check if required Python packages are available.
 python_available <- reticulate::py_module_available("scanpy") &&
@@ -57,7 +60,9 @@ If these are not available, the code chunks will not be evaluated but the exampl
 Install required Python packages if needed:
 
 ```{r python_setup, eval=FALSE}
-reticulate::py_require("scanpy")
+# TEMP(anndata<0.13.0): anndataR does not yet support Python anndata >= 0.13.0
+reticulate::py_require("scanpy>=1.10")
+reticulate::py_require("anndata<0.13.0")
 ```
 
 ```{r load_libraries}


### PR DESCRIPTION
Backports fixes from `devel` to `RELEASE_3_23`, limited to changes that fix functionality already present in the 3.23 release (no new features).

- Fix `create_zarr()` so that Zarr stores can be created at relative paths and at paths containing regex metacharacters (PR #478).
- Fix conditional expression in `AbstractAnnData` matrix validation (PR #487).
- Take into account the Rarr 2.1.0 structured datatype breaking change in Zarr tests (PR #462).
- Require Python `anndata<0.13.0` in tests, workflows and vignettes (PR #481).
- Update `CITATION` with the published paper (PR #464).