### PR TITLE
Remove zarr v3 rec array special handling

### DIFF
--- a/tests/testthat/test-Zarr-read.R
+++ b/tests/testthat/test-Zarr-read.R
@@ -115,12 +115,7 @@ for (zarr_format in c(2, 3)) {
   })
 
   test_that(paste("reading Zarr", zarr_format, "mappings works"), {
-    if (zarr_format == "3") {
-      # TODO: Remove when v3 recarray support is implemented
-      mapping <- suppressWarnings(read_zarr_mapping(store, "uns"))
-    } else {
-      mapping <- read_zarr_mapping(store, "uns")
-    }
+    mapping <- read_zarr_mapping(store, "uns")
     expect_type(mapping, "list")
     expect_type(names(mapping), "character")
   })


### PR DESCRIPTION
**Related to:** https://github.com/Huber-group-EMBL/Rarr/pull/174

## Description

v3 structured data types (rec arrays) are supported in Rarr since https://github.com/Huber-group-EMBL/Rarr/pull/174.

There is no need to bump the minimum required version since it's already high enough.

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
