### PR TITLE
Check each branch against its own Bioconductor version

### DIFF
--- a/.github/workflows/R-CMD-check-bioc.yaml
+++ b/.github/workflows/R-CMD-check-bioc.yaml
@@ -16,17 +16,37 @@ concurrency:
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-  ## Check `RELEASE_*` branches against Bioconductor release and everything else
-  ## against Bioconductor devel. `devel` depends on packages that only exist in
-  ## Bioconductor devel (currently `Rarr`, whose 2.1.x series *is* the devel
-  ## series), so checking it against release can never resolve dependencies.
-  BIOC_VERSION: ${{ startsWith(github.base_ref || github.ref_name, 'RELEASE_') && 'release' || 'devel' }}
 
 jobs:
+  ## Each `RELEASE_x_y` branch belongs to one Bioconductor version, so check it
+  ## against that version rather than against whichever release is current.
+  ## `devel` is checked against Bioconductor devel; it depends on packages that
+  ## only exist there, so checking it against a release can never resolve.
+  bioc-version:
+    runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+
+    steps:
+      - name: Resolve the Bioconductor version to check against
+        id: resolve
+        shell: bash
+        run: |
+          ref="${{ github.base_ref || github.ref_name }}"
+          case "$ref" in
+            RELEASE_*) version="${ref#RELEASE_}"; version="${version//_/.}" ;;
+            *)         version="devel" ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Checking '$ref' against Bioconductor $version"
+
   R-CMD-check-bioc:
+    needs: bioc-version
+
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ startsWith(github.base_ref || github.ref_name, 'RELEASE_') && 'release' || 'devel' }})
+    name: ${{ matrix.config.os }} (${{ needs.bioc-version.outputs.version }})
 
     strategy:
       fail-fast: false
@@ -65,7 +85,7 @@ jobs:
       - name: Setup R and Bioconductor
         uses: grimbough/bioc-actions/setup-bioc@v1
         with:
-          bioc-version: ${{ env.BIOC_VERSION }}
+          bioc-version: ${{ needs.bioc-version.outputs.version }}
           bioc-mirror: ${{ matrix.config.bioc-mirror }}
 
       - name: Install pandoc
@@ -135,7 +155,7 @@ jobs:
           path: ${{ steps.bioc-check.outputs.check-dir }}
 
       - name: Run BiocCheck
-        if: matrix.config.os == 'ubuntu-latest' && env.BIOC_VERSION == 'devel'
+        if: matrix.config.os == 'ubuntu-latest' && needs.bioc-version.outputs.version == 'devel'
         uses: grimbough/bioc-actions/run-BiocCheck@v1
         with:
           error-on: 'never'

--- a/.github/workflows/R-CMD-check-bioc.yaml
+++ b/.github/workflows/R-CMD-check-bioc.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - devel
+      - 'RELEASE_**'
   pull_request:
 
 name: R-CMD-check-bioc
@@ -15,22 +16,26 @@ concurrency:
 env:
   GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  ## Check `RELEASE_*` branches against Bioconductor release and everything else
+  ## against Bioconductor devel. `devel` depends on packages that only exist in
+  ## Bioconductor devel (currently `Rarr`, whose 2.1.x series *is* the devel
+  ## series), so checking it against release can never resolve dependencies.
+  BIOC_VERSION: ${{ startsWith(github.base_ref || github.ref_name, 'RELEASE_') && 'release' || 'devel' }}
 
 jobs:
   R-CMD-check-bioc:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.bioc-version }})
+    name: ${{ matrix.config.os }} (${{ startsWith(github.base_ref || github.ref_name, 'RELEASE_') && 'release' || 'devel' }})
 
     strategy:
       fail-fast: false
       matrix:
         config:
-        - { os: windows-latest, bioc-version: 'devel', bioc-mirror: 'https://bioconductor.posit.co/', cache: 1 }
-        - { os: macOS-latest,   bioc-version: 'devel', bioc-mirror: 'https://bioconductor.posit.co/', cache: 1 }
-        - { os: macOS-15-intel, bioc-version: 'devel', bioc-mirror: 'https://bioconductor.posit.co/', cache: 2 }
-        - { os: ubuntu-latest,  bioc-version: 'devel', bioc-mirror: 'https://bioconductor.posit.co/', cache: 1 }
-        - { os: ubuntu-latest,  bioc-version: 'release', bioc-mirror: 'https://bioconductor.posit.co/', cache: 1 }
+        - { os: windows-latest, bioc-mirror: 'https://bioconductor.posit.co/', cache: 1 }
+        - { os: macOS-latest,   bioc-mirror: 'https://bioconductor.posit.co/', cache: 1 }
+        - { os: macOS-15-intel, bioc-mirror: 'https://bioconductor.posit.co/', cache: 2 }
+        - { os: ubuntu-latest,  bioc-mirror: 'https://bioconductor.posit.co/', cache: 1 }
 
     steps:
 
@@ -60,7 +65,7 @@ jobs:
       - name: Setup R and Bioconductor
         uses: grimbough/bioc-actions/setup-bioc@v1
         with:
-          bioc-version: ${{ matrix.config.bioc-version }}
+          bioc-version: ${{ env.BIOC_VERSION }}
           bioc-mirror: ${{ matrix.config.bioc-mirror }}
 
       - name: Install pandoc
@@ -130,7 +135,7 @@ jobs:
           path: ${{ steps.bioc-check.outputs.check-dir }}
 
       - name: Run BiocCheck
-        if: matrix.config.os == 'ubuntu-latest' && matrix.config.bioc-version == 'devel'
+        if: matrix.config.os == 'ubuntu-latest' && env.BIOC_VERSION == 'devel'
         uses: grimbough/bioc-actions/run-BiocCheck@v1
         with:
           error-on: 'never'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # anndataR devel
 
 - Add support for `nullable-string-array` elements in H5AD and Zarr (PR #480)
+- Check `RELEASE_*` branches against Bioconductor release and `devel` against Bioconductor devel, instead of checking `devel` against both (PR #502).
 
 # anndataR 1.3.1
 


### PR DESCRIPTION
**Related to:** the `ubuntu-latest (release)` check that has been red on `devel` since #455

## Description

Checking `devel` against Bioconductor release was never going to work while `devel`
depends on devel-only packages. This PR derives the Bioc version from the branch.

The r-universe checks don't make this workflow redundant atm, since the runner has no `h5diff` and
skips the byte-level roundtrip comparisons in `test-roundtrip-*.R`.

We'll want to backport this to the release branches

## Checklist

**Before review**

- [ ] Update and regenerate man pages
- [ ] Add/update tests
- [ ] Add/update examples in vignettes
- [x] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [ ] Bump devel version