### PR TITLE
Run BiocCheck on release branches too

### DIFF
--- a/.github/workflows/R-CMD-check-bioc.yaml
+++ b/.github/workflows/R-CMD-check-bioc.yaml
@@ -155,7 +155,7 @@ jobs:
           path: ${{ steps.bioc-check.outputs.check-dir }}
 
       - name: Run BiocCheck
-        if: matrix.config.os == 'ubuntu-latest' && needs.bioc-version.outputs.version == 'devel'
+        if: matrix.config.os == 'ubuntu-latest'
         uses: grimbough/bioc-actions/run-BiocCheck@v1
         with:
           error-on: 'never'

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - Add support for `nullable-string-array` elements in H5AD and Zarr (PR #480)
 - Check `RELEASE_*` branches against Bioconductor release and `devel` against Bioconductor devel, instead of checking `devel` against both (PR #502).
+- Run BiocCheck on `RELEASE_*` branches as well as on `devel` (PR #504).
 
 # anndataR 1.3.1
 


### PR DESCRIPTION
**Related to:** #502, #503

## Description

Follow-up to #502: BiocCheck is gated on the resolved Bioconductor version being `devel`, so on a `RELEASE_*` branch it no longer runs at all. Before #502 the `ubuntu-latest` + devel matrix leg meant it ran on every branch.

- Run BiocCheck on `ubuntu-latest` regardless of the resolved version. Every branch is now checked against the version it targets, so BiocCheck is meaningful on both.

Noticed while backporting #502 to `RELEASE_3_23` in #503, which carries the same one-line change.

## Checklist

**Before review**

- [x] Update and regenerate man pages <!-- n/a, CI only -->
- [x] Add/update tests <!-- n/a, CI only -->
- [x] Add/update examples in vignettes <!-- n/a, CI only -->
- [ ] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [x] Bump devel version <!-- n/a, no package code changed -->
