### PR TITLE
Add Support for Zarr-backed DelayedArray reading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Suggests:
     BiocStyle,
     DelayedArray,
     HDF5Array,
+    ZarrArray,
     jsonlite,
     knitr,
     processx,

--- a/R/ZarrAnnData.R
+++ b/R/ZarrAnnData.R
@@ -314,6 +314,8 @@ ZarrAnnData <- R6::R6Class(
     #'   both `X` or `obs` and `var` are not provided.
     #' @param mode The mode to open the Zarr file. See [as_ZarrAnnData()] for
     #'   details
+    #' @param backed Whether the object is disk backed. See [as_ZarrAnnData()]
+    #'   for details
     #' @param compression The compression algorithm to use. See
     #'   [as_ZarrAnnData()] for details
     #' @param zarr_format The Zarr format to use. See
@@ -599,6 +601,9 @@ ZarrAnnData <- R6::R6Class(
 #'   * `r+` opens an existing file for read/write
 #'   * `w` creates a file, truncating any existing ones
 #'   * `w-`/`x` are synonyms, creating a file and failing if it already exists
+#' @param backed Whether the object is disk backed and returns
+#'   [DelayedArray::DelayedArray] object for matrix data. Can only be `TRUE`
+#'   when `mode == "r"`.
 #' @param zarr_format The format to use when creating the Zarr store. Should be
 #'   either 2 or 3 for Zarr v2 or v3 formats, respectively. The default can also
 #'   be set using the `anndataR.zarr_format` option, e.g.
@@ -630,6 +635,7 @@ as_ZarrAnnData <- function(
     "lz4"
   ),
   mode = c("w-", "r", "r+", "a", "w", "x"),
+  backed = FALSE,
   zarr_format = NULL
 ) {
   if (!(inherits(adata, "AbstractAnnData"))) {
@@ -653,6 +659,7 @@ as_ZarrAnnData <- function(
     shape = adata$shape(),
     mode = mode,
     compression = compression,
+    backed = backed,
     zarr_format = zarr_format
   )
 }

--- a/R/ZarrAnnData.R
+++ b/R/ZarrAnnData.R
@@ -75,9 +75,11 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_layers, status=done
-        read_zarr_element(private$.zarrobj, 
-                          "layers", 
-                          backed = private$.backed) |>
+        read_zarr_element(
+          private$.zarrobj,
+          "layers",
+          backed = private$.backed
+        ) |>
           private$.add_mapping_dimnames("layers")
       } else {
         private$.check_writeable()
@@ -103,9 +105,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_obsm, status=done
-        read_zarr_element(private$.zarrobj, 
-                          "obsm", 
-                          backed = private$.backed) |>
+        read_zarr_element(private$.zarrobj, "obsm", backed = private$.backed) |>
           private$.add_mapping_dimnames("obsm")
       } else {
         private$.check_writeable()
@@ -133,9 +133,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_varm, status=done
-        read_zarr_element(private$.zarrobj, 
-                          "varm", 
-                          backed = private$.backed) |>
+        read_zarr_element(private$.zarrobj, "varm", backed = private$.backed) |>
           private$.add_mapping_dimnames("varm")
       } else {
         private$.check_writeable()
@@ -163,9 +161,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_obsp, status=done
-        read_zarr_element(private$.zarrobj, 
-                          "obsp", 
-                          backed = private$.backed) |>
+        read_zarr_element(private$.zarrobj, "obsp", backed = private$.backed) |>
           private$.add_mapping_dimnames("obsp")
       } else {
         private$.check_writeable()
@@ -191,9 +187,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_varp, status=done
-        read_zarr_element(private$.zarrobj, 
-                          "varp", 
-                          backed = private$.backed) |>
+        read_zarr_element(private$.zarrobj, "varp", backed = private$.backed) |>
           private$.add_mapping_dimnames("varp")
       } else {
         private$.check_writeable()
@@ -219,9 +213,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_obs, status=done
-        read_zarr_element(private$.zarrobj, 
-                          "obs", 
-                          backed = private$.backed)
+        read_zarr_element(private$.zarrobj, "obs", backed = private$.backed)
       } else {
         private$.check_writeable()
         # trackstatus: class=ZarrAnnData, feature=set_obs, status=done
@@ -240,9 +232,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_var, status=done
-        read_zarr_element(private$.zarrobj, 
-                          "var", 
-                          backed = private$.backed)
+        read_zarr_element(private$.zarrobj, "var", backed = private$.backed)
       } else {
         private$.check_writeable()
         # trackstatus: class=ZarrAnnData, feature=set_var, status=done
@@ -381,7 +371,7 @@ ZarrAnnData <- R6::R6Class(
             mode <- "w-"
           }
         }
-        
+
         if (backed && mode != "r") {
           cli_warn(
             paste(
@@ -392,7 +382,7 @@ ZarrAnnData <- R6::R6Class(
           backed <- FALSE
         }
         private$.backed <- backed
-        
+
         if (isTRUE(private$.backed)) {
           check_requires(
             "Reading a backed ZarrAnnData",
@@ -574,8 +564,8 @@ ZarrAnnData <- R6::R6Class(
     #' @description See [AnnData-usage]
     uns_keys = function() {
       read_zarr_element_keys(private$.zarrobj, "uns")
-    }, 
-    
+    },
+
     #' @description Convert to an [`InMemoryAnnData`]. Any backed
     #'   (`DelayedArray`) slots are materialized into ordinary in-memory
     #'   matrices: an in-memory object should not stay tied to an on-disk file.
@@ -584,6 +574,7 @@ ZarrAnnData <- R6::R6Class(
         prev <- private$.backed
         private$.backed <- FALSE
         on.exit(private$.backed <- prev, add = TRUE)
+        # TODO: commenting out for now, but irrelevant to Zarr
         # Hold the file open for the whole multi-slot read (single handle).
         # private$.hdf5_file$open_and_defer_close(readonly = TRUE)
       }

--- a/R/ZarrAnnData.R
+++ b/R/ZarrAnnData.R
@@ -347,6 +347,7 @@ ZarrAnnData <- R6::R6Class(
       uns = NULL,
       shape = NULL,
       mode = c("a", "r", "r+", "w", "w-", "x"),
+      backed = FALSE,
       compression = c(
         "none",
         "gzip",

--- a/R/ZarrAnnData.R
+++ b/R/ZarrAnnData.R
@@ -21,6 +21,7 @@ ZarrAnnData <- R6::R6Class(
   private = list(
     .zarrobj = NULL,
     .zarrformat = NULL,
+    .backed = NULL,
     .compression = NULL,
     .readonly = NULL,
 
@@ -48,7 +49,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_X, status=done
-        read_zarr_element(private$.zarrobj, "X") |>
+        read_zarr_element(private$.zarrobj, "X", backed = private$.backed) |>
           private$.add_matrix_dimnames("X")
       } else {
         private$.check_writeable()
@@ -74,7 +75,9 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_layers, status=done
-        read_zarr_element(private$.zarrobj, "layers") |>
+        read_zarr_element(private$.zarrobj, 
+                          "layers", 
+                          backed = private$.backed) |>
           private$.add_mapping_dimnames("layers")
       } else {
         private$.check_writeable()
@@ -100,7 +103,9 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_obsm, status=done
-        read_zarr_element(private$.zarrobj, "obsm") |>
+        read_zarr_element(private$.zarrobj, 
+                          "obsm", 
+                          backed = private$.backed) |>
           private$.add_mapping_dimnames("obsm")
       } else {
         private$.check_writeable()
@@ -128,7 +133,9 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_varm, status=done
-        read_zarr_element(private$.zarrobj, "varm") |>
+        read_zarr_element(private$.zarrobj, 
+                          "varm", 
+                          backed = private$.backed) |>
           private$.add_mapping_dimnames("varm")
       } else {
         private$.check_writeable()
@@ -156,7 +163,9 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_obsp, status=done
-        read_zarr_element(private$.zarrobj, "obsp") |>
+        read_zarr_element(private$.zarrobj, 
+                          "obsp", 
+                          backed = private$.backed) |>
           private$.add_mapping_dimnames("obsp")
       } else {
         private$.check_writeable()
@@ -182,7 +191,9 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_varp, status=done
-        read_zarr_element(private$.zarrobj, "varp") |>
+        read_zarr_element(private$.zarrobj, 
+                          "varp", 
+                          backed = private$.backed) |>
           private$.add_mapping_dimnames("varp")
       } else {
         private$.check_writeable()
@@ -208,7 +219,9 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_obs, status=done
-        read_zarr_element(private$.zarrobj, "obs")
+        read_zarr_element(private$.zarrobj, 
+                          "obs", 
+                          backed = private$.backed)
       } else {
         private$.check_writeable()
         # trackstatus: class=ZarrAnnData, feature=set_obs, status=done
@@ -227,7 +240,9 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_var, status=done
-        read_zarr_element(private$.zarrobj, "var")
+        read_zarr_element(private$.zarrobj, 
+                          "var", 
+                          backed = private$.backed)
       } else {
         private$.check_writeable()
         # trackstatus: class=ZarrAnnData, feature=set_var, status=done
@@ -272,7 +287,7 @@ ZarrAnnData <- R6::R6Class(
 
       if (missing(value)) {
         # trackstatus: class=ZarrAnnData, feature=get_uns, status=done
-        read_zarr_element(private$.zarrobj, "uns")
+        read_zarr_element(private$.zarrobj, "uns", backed = private$.backed)
       } else {
         private$.check_writeable()
         # trackstatus: class=ZarrAnnData, feature=set_uns, status=done
@@ -364,6 +379,25 @@ ZarrAnnData <- R6::R6Class(
           } else {
             mode <- "w-"
           }
+        }
+        
+        if (backed && mode != "r") {
+          cli_warn(
+            paste(
+              "{.arg backed} can only be {.val TRUE} when {.arg mode} is {.val 'r'}.",
+              "Setting {.arg backed} to {.val FALSE}."
+            )
+          )
+          backed <- FALSE
+        }
+        private$.backed <- backed
+        
+        if (isTRUE(private$.backed)) {
+          check_requires(
+            "Reading a backed ZarrAnnData",
+            c("ZarrArray", "DelayedArray"),
+            where = "Bioc"
+          )
         }
 
         if (!dir.exists(file) && mode %in% c("r", "r+")) {
@@ -539,6 +573,20 @@ ZarrAnnData <- R6::R6Class(
     #' @description See [AnnData-usage]
     uns_keys = function() {
       read_zarr_element_keys(private$.zarrobj, "uns")
+    }, 
+    
+    #' @description Convert to an [`InMemoryAnnData`]. Any backed
+    #'   (`DelayedArray`) slots are materialized into ordinary in-memory
+    #'   matrices: an in-memory object should not stay tied to an on-disk file.
+    as_InMemoryAnnData = function() {
+      if (isTRUE(private$.backed)) {
+        prev <- private$.backed
+        private$.backed <- FALSE
+        on.exit(private$.backed <- prev, add = TRUE)
+        # Hold the file open for the whole multi-slot read (single handle).
+        # private$.hdf5_file$open_and_defer_close(readonly = TRUE)
+      }
+      super$as_InMemoryAnnData()
     }
   )
 )

--- a/R/read_zarr.R
+++ b/R/read_zarr.R
@@ -19,7 +19,7 @@
 #'   * `r+` opens an existing file for read/write.
 #'   * `w` creates a file, truncating any existing ones.
 #'   * `w-`/`x` are synonyms, creating a file and failing if it already exists.
-#' @param backed Whether to read the H5AD file in backed mode, returning an
+#' @param backed Whether to read the Zarr store in backed mode, returning an
 #'  object containing [DelayedArray::DelayedMatrix] matrices. Which slots are
 #'  backed depends on the value of `as`.
 #' @param ... Extra arguments provided to the `as_*` conversion function for the

--- a/R/read_zarr.R
+++ b/R/read_zarr.R
@@ -19,6 +19,9 @@
 #'   * `r+` opens an existing file for read/write.
 #'   * `w` creates a file, truncating any existing ones.
 #'   * `w-`/`x` are synonyms, creating a file and failing if it already exists.
+#' @param backed Whether to read the H5AD file in backed mode, returning an
+#'  object containing [DelayedArray::DelayedMatrix] matrices. Which slots are
+#'  backed depends on the value of `as`.
 #' @param ... Extra arguments provided to the `as_*` conversion function for the
 #'   object specified by `as`
 #'
@@ -47,12 +50,13 @@ read_zarr <- function(
   path,
   as = c("InMemoryAnnData", "ZarrAnnData", "SingleCellExperiment", "Seurat"),
   mode = c("r", "r+", "a", "w", "w-", "x"),
+  backed = FALSE,
   ...
 ) {
   as <- match.arg(as)
   mode <- match.arg(mode)
 
-  zarr_adata <- ZarrAnnData$new(path, mode = mode)
+  zarr_adata <- ZarrAnnData$new(path, mode = mode, backed = backed)
 
   if (as == "ZarrAnnData") {
     return(zarr_adata)

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -59,11 +59,13 @@ read_zarr_element <- function(
 
   tryCatch(
     {
-      read_fun(store = store, 
-               name = name, 
-               version = version, 
-               backed = backed, 
-               ...)
+      read_fun(
+        store = store,
+        name = name,
+        version = version,
+        backed = backed,
+        ...
+      )
     },
     error = function(e) {
       msg <- cli::cli_fmt(cli::cli_bullets(c(
@@ -188,16 +190,21 @@ read_zarr_null <- function(store, name, version = "0.1.0") {
 #' @return A matrix or a vector if 1D
 #'
 #' @noRd
-read_zarr_dense_array <- function(store, name, backed = FALSE, version = "0.2.0") {
+read_zarr_dense_array <- function(
+  store,
+  name,
+  backed = FALSE,
+  version = "0.2.0"
+) {
   version <- match.arg(version)
 
   # Eager reads use base {rhdf5} directly
   if (!isTRUE(backed)) {
     return(read_zarr_dense_array_base(store, name, version))
   }
-  
+
   data <- ZarrArray::ZarrArray(file.path(store, name))
-  
+
   data
 }
 
@@ -212,9 +219,9 @@ read_zarr_dense_array <- function(store, name, backed = FALSE, version = "0.2.0"
 #' @noRd
 read_zarr_dense_array_base <- function(store, name, version = "0.2.0") {
   version <- match.arg(version)
-  
+
   data <- Rarr::read_zarr_array(file.path(store, name))
-  
+
   data
 }
 
@@ -263,7 +270,7 @@ read_zarr_sparse_array <- function(
   if (!isTRUE(backed)) {
     return(read_zarr_sparse_array_base(store, name, version, type))
   }
-  
+
   t(ZarrArray::ZarrSparseMatrix(store, group = name))
 }
 
@@ -279,16 +286,16 @@ read_zarr_sparse_array <- function(
 #'
 #' @noRd
 read_zarr_sparse_array_base <- function(
-    store,
-    name,
-    version = "0.1.0",
-    type = c("csr_matrix", "csc_matrix")
+  store,
+  name,
+  version = "0.1.0",
+  type = c("csr_matrix", "csc_matrix")
 ) {
   version <- match.arg(version)
   type <- match.arg(type)
-  
+
   attrs <- Rarr::read_zarr_attributes(file.path(store, name))
-  
+
   construct_sparse_matrix(
     data = as.vector(Rarr::read_zarr_array(file.path(store, name, "data"))),
     indices = as.vector(Rarr::read_zarr_array(file.path(
@@ -506,19 +513,19 @@ read_zarr_mapping <- function(store, name, version = "0.1.0", backed = FALSE) {
 #' @inheritParams read_zarr_element
 #' @param backed Whether to return DelayedArrays for array/matrix types (always
 #' `FALSE`)
-#' 
+#'
 #' @details
 #' The `backed` argument is included to avoid `backed` being passed via `...`
 #' and is always overwritten to `FALSE` since data frame columns should not be
 #' DelayedArrays.
-#' 
+#'
 #' @return A data.frame
 #'
 #' @noRd
 read_zarr_data_frame <- function(
   store,
   name,
-  version = "0.2.0", 
+  version = "0.2.0",
   backed = FALSE
 ) {
   version <- match.arg(version)

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -365,6 +365,7 @@ read_zarr_nullable_integer <- function(store, name, version = "0.1.0") {
 #' @param store A Zarr store instance
 #' @param name Name of the element within the Zarr store
 #' @param version Encoding version of the element to read
+#' @param ...
 #'
 #' @details
 #' **NOTE:** This implementation ignores the `"na-value"` attribute, see
@@ -373,7 +374,7 @@ read_zarr_nullable_integer <- function(store, name, version = "0.1.0") {
 #' @return A character vector
 #'
 #' @noRd
-read_zarr_nullable_string <- function(store, name, version = "0.1.0") {
+read_zarr_nullable_string <- function(store, name, version = "0.1.0", ...) {
   as.character(read_zarr_nullable(store, name, version))
 }
 

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -175,7 +175,7 @@ read_zarr_encoding <- function(store, name) {
 #'
 #' @return `NULL`
 #' @noRd
-read_zarr_null <- function(store, name, version = "0.1.0") {
+read_zarr_null <- function(store, name, version = "0.1.0", ...) {
   version <- match.arg(version)
 
   NULL
@@ -194,7 +194,8 @@ read_zarr_dense_array <- function(
   store,
   name,
   backed = FALSE,
-  version = "0.2.0"
+  version = "0.2.0", 
+  ...
 ) {
   version <- match.arg(version)
 
@@ -217,7 +218,7 @@ read_zarr_dense_array <- function(
 #' @return A matrix or a vector if 1D
 #'
 #' @noRd
-read_zarr_dense_array_base <- function(store, name, version = "0.2.0") {
+read_zarr_dense_array_base <- function(store, name, version = "0.2.0", ...) {
   version <- match.arg(version)
 
   data <- Rarr::read_zarr_array(file.path(store, name))
@@ -225,7 +226,7 @@ read_zarr_dense_array_base <- function(store, name, version = "0.2.0") {
   data
 }
 
-read_zarr_csr_matrix <- function(store, name, backed = FALSE, version) {
+read_zarr_csr_matrix <- function(store, name, backed = FALSE, version, ...) {
   read_zarr_sparse_array(
     store = store,
     name = name,
@@ -235,7 +236,7 @@ read_zarr_csr_matrix <- function(store, name, backed = FALSE, version) {
   )
 }
 
-read_zarr_csc_matrix <- function(store, name, backed = FALSE, version) {
+read_zarr_csc_matrix <- function(store, name, backed = FALSE, version, ...) {
   read_zarr_sparse_array(
     store = store,
     name = name,
@@ -261,7 +262,8 @@ read_zarr_sparse_array <- function(
   name,
   backed = FALSE,
   version = "0.1.0",
-  type = c("csr_matrix", "csc_matrix")
+  type = c("csr_matrix", "csc_matrix"), 
+  ...
 ) {
   version <- match.arg(version)
   type <- match.arg(type)
@@ -289,7 +291,8 @@ read_zarr_sparse_array_base <- function(
   store,
   name,
   version = "0.1.0",
-  type = c("csr_matrix", "csc_matrix")
+  type = c("csr_matrix", "csc_matrix"),
+  ...
 ) {
   version <- match.arg(version)
   type <- match.arg(type)
@@ -326,7 +329,7 @@ read_zarr_sparse_array_base <- function(
 #' @return A named list of 1D arrays
 #'
 #' @noRd
-read_zarr_rec_array <- function(store, name, version = "0.2.0") {
+read_zarr_rec_array <- function(store, name, version = "0.2.0", ...) {
   version <- match.arg(version)
   Rarr::read_zarr_array(file.path(store, name)) |>
     lapply(as.vector)
@@ -341,7 +344,7 @@ read_zarr_rec_array <- function(store, name, version = "0.2.0") {
 #' @return A boolean vector
 #'
 #' @noRd
-read_zarr_nullable_boolean <- function(store, name, version = "0.1.0") {
+read_zarr_nullable_boolean <- function(store, name, version = "0.1.0", ...) {
   as.logical(read_zarr_nullable(store, name, version))
 }
 
@@ -354,7 +357,7 @@ read_zarr_nullable_boolean <- function(store, name, version = "0.1.0") {
 #' @return An integer vector
 #'
 #' @noRd
-read_zarr_nullable_integer <- function(store, name, version = "0.1.0") {
+read_zarr_nullable_integer <- function(store, name, version = "0.1.0", ...) {
   as.integer(read_zarr_nullable(store, name, version))
 }
 
@@ -387,7 +390,7 @@ read_zarr_nullable_string <- function(store, name, version = "0.1.0", ...) {
 #' @return A nullable vector
 #'
 #' @noRd
-read_zarr_nullable <- function(store, name, version = "0.1.0") {
+read_zarr_nullable <- function(store, name, version = "0.1.0", ...) {
   version <- match.arg(version)
 
   mask <- Rarr::read_zarr_array(file.path(store, paste0(name, "/mask")))
@@ -411,7 +414,7 @@ read_zarr_nullable <- function(store, name, version = "0.1.0") {
 #' @return A character vector/matrix
 #'
 #' @noRd
-read_zarr_string_array <- function(store, name, version = "0.2.0") {
+read_zarr_string_array <- function(store, name, version = "0.2.0", ...) {
   version <- match.arg(version)
 
   data <- Rarr::read_zarr_array(file.path(store, name))
@@ -433,7 +436,7 @@ read_zarr_string_array <- function(store, name, version = "0.2.0") {
 #' @return A factor
 #'
 #' @noRd
-read_zarr_categorical <- function(store, name, version = "0.2.0") {
+read_zarr_categorical <- function(store, name, version = "0.2.0", ...) {
   version <- match.arg(version)
 
   codes <- Rarr::read_zarr_array(file.path(store, paste0(name, "/codes")))
@@ -467,7 +470,7 @@ read_zarr_categorical <- function(store, name, version = "0.2.0") {
 #' @return A character vector of length 1
 #'
 #' @noRd
-read_zarr_string_scalar <- function(store, name, version = "0.2.0") {
+read_zarr_string_scalar <- function(store, name, version = "0.2.0", ...) {
   version <- match.arg(version)
   as.character(Rarr::read_zarr_array(file.path(store, name)))
 }
@@ -481,7 +484,7 @@ read_zarr_string_scalar <- function(store, name, version = "0.2.0") {
 #' @return A numeric vector of length 1
 #'
 #' @noRd
-read_zarr_numeric_scalar <- function(store, name, version = "0.2.0") {
+read_zarr_numeric_scalar <- function(store, name, version = "0.2.0", ...) {
   version <- match.arg(version)
 
   value <- Rarr::read_zarr_array(file.path(store, name))
@@ -501,7 +504,7 @@ read_zarr_numeric_scalar <- function(store, name, version = "0.2.0") {
 #' @return A named list
 #'
 #' @noRd
-read_zarr_mapping <- function(store, name, version = "0.1.0", backed = FALSE) {
+read_zarr_mapping <- function(store, name, version = "0.1.0", backed = FALSE, ...) {
   version <- match.arg(version)
   items <- read_zarr_mapping_keys(store, name, version)
   read_zarr_collection(store, name, items, backed = backed)
@@ -527,7 +530,8 @@ read_zarr_data_frame <- function(
   store,
   name,
   version = "0.2.0",
-  backed = FALSE
+  backed = FALSE, 
+  ...
 ) {
   version <- match.arg(version)
 
@@ -550,7 +554,7 @@ read_zarr_data_frame <- function(
 #' @return A named list
 #'
 #' @noRd
-read_zarr_collection <- function(store, name, item_names, backed = FALSE) {
+read_zarr_collection <- function(store, name, item_names, backed = FALSE, ...) {
   items <- lapply(
     item_names,
     function(item_name) {
@@ -578,7 +582,7 @@ read_zarr_collection <- function(store, name, item_names, backed = FALSE) {
 #' @return A character vector of item names
 #'
 #' @noRd
-read_zarr_mapping_keys <- function(store, name, version = "0.1.0") {
+read_zarr_mapping_keys <- function(store, name, version = "0.1.0", ...) {
   version <- match.arg(version)
 
   items <- list.dirs(

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -172,6 +172,7 @@ read_zarr_encoding <- function(store, name) {
 #' Read a null value from an Zarr store
 #'
 #' @inheritParams read_zarr_element
+#' @param ... Extra arguments for other reading functions (not used)
 #'
 #' @return `NULL`
 #' @noRd
@@ -368,7 +369,7 @@ read_zarr_nullable_integer <- function(store, name, version = "0.1.0", ...) {
 #' @param store A Zarr store instance
 #' @param name Name of the element within the Zarr store
 #' @param version Encoding version of the element to read
-#' @param ...
+#' @param ... Extra arguments for other reading functions (not used)
 #'
 #' @details
 #' **NOTE:** This implementation ignores the `"na-value"` attribute, see

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -196,13 +196,7 @@ read_zarr_dense_array <- function(store, name, backed = FALSE, version = "0.2.0"
     return(read_zarr_dense_array_base(store, name, version))
   }
   
-  data <- ZarrArray::ZarrArray(hdf5_file$path, name, type = dataset_type)
-  
-  if (length(dim(data)) == 2) {
-    data <- t(data)
-  } else if (length(dim(data)) > 2) {
-    data <- aperm(data)
-  }
+  data <- ZarrArray::ZarrArray(file.path(store, name))
   
   data
 }
@@ -270,7 +264,7 @@ read_zarr_sparse_array <- function(
     return(read_zarr_sparse_array_base(store, name, version, type))
   }
   
-  t(ZarrArray::ZarrSparseMatrix(store, name))
+  t(ZarrArray::ZarrSparseMatrix(store, group = name))
 }
 
 #' Read Zarr sparse array (base)
@@ -284,7 +278,7 @@ read_zarr_sparse_array <- function(
 #' @importFrom Matrix sparseMatrix
 #'
 #' @noRd
-read_zarr_sparse_array <- function(
+read_zarr_sparse_array_base <- function(
     store,
     name,
     version = "0.1.0",
@@ -525,7 +519,7 @@ read_zarr_data_frame <- function(
   store,
   name,
   version = "0.2.0", 
-  backed = FALSE,
+  backed = FALSE
 ) {
   version <- match.arg(version)
 

--- a/R/read_zarr_helpers.R
+++ b/R/read_zarr_helpers.R
@@ -7,6 +7,7 @@
 #' @param type The encoding type of the element to read
 #' @param version The encoding version of the element to read
 #' @param stop_on_error Whether to stop on error or generate a warning instead
+#' @param backed Whether to return a DelayedArray for array/matrix types
 #' @param ... Extra arguments passed to individual reading functions
 #'
 #' @details
@@ -22,6 +23,7 @@ read_zarr_element <- function(
   type = NULL,
   version = NULL,
   stop_on_error = FALSE,
+  backed = FALSE,
   ...
 ) {
   if (!zarr_path_exists(store, name)) {
@@ -57,7 +59,11 @@ read_zarr_element <- function(
 
   tryCatch(
     {
-      read_fun(store = store, name = name, version = version, ...)
+      read_fun(store = store, 
+               name = name, 
+               version = version, 
+               backed = backed, 
+               ...)
     },
     error = function(e) {
       msg <- cli::cli_fmt(cli::cli_bullets(c(
@@ -182,27 +188,57 @@ read_zarr_null <- function(store, name, version = "0.1.0") {
 #' @return A matrix or a vector if 1D
 #'
 #' @noRd
-read_zarr_dense_array <- function(store, name, version = "0.2.0") {
+read_zarr_dense_array <- function(store, name, backed = FALSE, version = "0.2.0") {
   version <- match.arg(version)
 
-  data <- Rarr::read_zarr_array(file.path(store, name))
-
+  # Eager reads use base {rhdf5} directly
+  if (!isTRUE(backed)) {
+    return(read_zarr_dense_array_base(store, name, version))
+  }
+  
+  data <- ZarrArray::ZarrArray(hdf5_file$path, name, type = dataset_type)
+  
+  if (length(dim(data)) == 2) {
+    data <- t(data)
+  } else if (length(dim(data)) > 2) {
+    data <- aperm(data)
+  }
+  
   data
 }
 
-read_zarr_csr_matrix <- function(store, name, version) {
+#' Read Zarr dense array (base)
+#'
+#' Read a dense array from a Zarr store using base (Rarr)
+#'
+#' @inheritParams read_zarr_element
+#'
+#' @return A matrix or a vector if 1D
+#'
+#' @noRd
+read_zarr_dense_array_base <- function(store, name, version = "0.2.0") {
+  version <- match.arg(version)
+  
+  data <- Rarr::read_zarr_array(file.path(store, name))
+  
+  data
+}
+
+read_zarr_csr_matrix <- function(store, name, backed = FALSE, version) {
   read_zarr_sparse_array(
     store = store,
     name = name,
+    backed = backed,
     version = version,
     type = "csr_matrix"
   )
 }
 
-read_zarr_csc_matrix <- function(store, name, version) {
+read_zarr_csc_matrix <- function(store, name, backed = FALSE, version) {
   read_zarr_sparse_array(
     store = store,
     name = name,
+    backed = backed,
     version = version,
     type = "csc_matrix"
   )
@@ -222,14 +258,43 @@ read_zarr_csc_matrix <- function(store, name, version) {
 read_zarr_sparse_array <- function(
   store,
   name,
+  backed = FALSE,
   version = "0.1.0",
   type = c("csr_matrix", "csc_matrix")
 ) {
   version <- match.arg(version)
   type <- match.arg(type)
 
-  attrs <- Rarr::read_zarr_attributes(file.path(store, name))
+  # Eager reads use base {rhdf5} directly
+  if (!isTRUE(backed)) {
+    return(read_zarr_sparse_array_base(store, name, version, type))
+  }
+  
+  t(ZarrArray::ZarrSparseMatrix(store, name))
+}
 
+#' Read Zarr sparse array (base)
+#'
+#' Read a sparse array from a Zarr store using base (Rarr)
+#'
+#' @inheritParams read_zarr_element
+#' @param type Type of the sparse matrix, either "csr_matrix" or "csc_matrix"
+#'
+#' @return A sparse matrix/DelayedArray???, or a vector if 1D
+#' @importFrom Matrix sparseMatrix
+#'
+#' @noRd
+read_zarr_sparse_array <- function(
+    store,
+    name,
+    version = "0.1.0",
+    type = c("csr_matrix", "csc_matrix")
+) {
+  version <- match.arg(version)
+  type <- match.arg(type)
+  
+  attrs <- Rarr::read_zarr_attributes(file.path(store, name))
+  
   construct_sparse_matrix(
     data = as.vector(Rarr::read_zarr_array(file.path(store, name, "data"))),
     indices = as.vector(Rarr::read_zarr_array(file.path(
@@ -434,10 +499,10 @@ read_zarr_numeric_scalar <- function(store, name, version = "0.2.0") {
 #' @return A named list
 #'
 #' @noRd
-read_zarr_mapping <- function(store, name, version = "0.1.0") {
+read_zarr_mapping <- function(store, name, version = "0.1.0", backed = FALSE) {
   version <- match.arg(version)
   items <- read_zarr_mapping_keys(store, name, version)
-  read_zarr_collection(store, name, items)
+  read_zarr_collection(store, name, items, backed = backed)
 }
 
 #' Read Zarr data frame
@@ -445,14 +510,22 @@ read_zarr_mapping <- function(store, name, version = "0.1.0") {
 #' Read a data frame from a Zarr store
 #'
 #' @inheritParams read_zarr_element
-#'
+#' @param backed Whether to return DelayedArrays for array/matrix types (always
+#' `FALSE`)
+#' 
+#' @details
+#' The `backed` argument is included to avoid `backed` being passed via `...`
+#' and is always overwritten to `FALSE` since data frame columns should not be
+#' DelayedArrays.
+#' 
 #' @return A data.frame
 #'
 #' @noRd
 read_zarr_data_frame <- function(
   store,
   name,
-  version = "0.2.0"
+  version = "0.2.0", 
+  backed = FALSE,
 ) {
   version <- match.arg(version)
 
@@ -475,7 +548,7 @@ read_zarr_data_frame <- function(
 #' @return A named list
 #'
 #' @noRd
-read_zarr_collection <- function(store, name, item_names) {
+read_zarr_collection <- function(store, name, item_names, backed = FALSE) {
   items <- lapply(
     item_names,
     function(item_name) {
@@ -485,7 +558,8 @@ read_zarr_collection <- function(store, name, item_names) {
         store = store,
         name = new_name,
         type = encoding$type,
-        version = encoding$version
+        version = encoding$version,
+        backed = backed
       )
     }
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -68,9 +68,13 @@ to_py_matrix <- function(mat) {
 to_R_matrix <- function(mat, allow_backed = TRUE) {
   if (inherits(mat, "DelayedMatrix") && isFALSE(allow_backed)) {
     seed <- DelayedArray::seed(mat)
-    if (inherits(seed, "CSC_H5SparseMatrixSeed")) {
+    if (
+      inherits(seed, c("CSC_H5SparseMatrixSeed", "CSC_ZarrSparseMatrixSeed"))
+    ) {
       mat <- as(mat, "CsparseMatrix")
-    } else if (inherits(seed, "CSR_H5SparseMatrixSeed")) {
+    } else if (
+      inherits(seed, c("CSR_H5SparseMatrixSeed", "CSR_ZarrSparseMatrixSeed"))
+    ) {
       mat <- as(mat, "RsparseMatrix")
     } else {
       mat <- as.matrix(mat)

--- a/man/HDF5AnnData.Rd
+++ b/man/HDF5AnnData.Rd
@@ -307,8 +307,6 @@ file will be overwritten.
   Convert to an \code{\link{InMemoryAnnData}}. Any backed
 (\code{DelayedArray}) slots are materialized into ordinary in-memory
 matrices: an in-memory object should not stay tied to an on-disk file.
-Slots are read eagerly (via base {rhdf5}) rather than carried over as
-DelayedArrays, which is also faster than realizing them.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{HDF5AnnData$as_InMemoryAnnData()}

--- a/man/ZarrAnnData.Rd
+++ b/man/ZarrAnnData.Rd
@@ -70,12 +70,12 @@ Other AnnData classes:
     \item \href{#method-ZarrAnnData-obsp_keys}{\code{ZarrAnnData$obsp_keys()}}
     \item \href{#method-ZarrAnnData-varp_keys}{\code{ZarrAnnData$varp_keys()}}
     \item \href{#method-ZarrAnnData-uns_keys}{\code{ZarrAnnData$uns_keys()}}
+    \item \href{#method-ZarrAnnData-as_InMemoryAnnData}{\code{ZarrAnnData$as_InMemoryAnnData()}}
   }
 }
 \if{html}{\out{<details><summary>Inherited methods</summary>
 <ul>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_HDF5AnnData"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_HDF5AnnData'><code>AbstractAnnData$as_HDF5AnnData()</code></a></span></li>
-  <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_InMemoryAnnData"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_InMemoryAnnData'><code>AbstractAnnData$as_InMemoryAnnData()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_ReticulateAnnData"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_ReticulateAnnData'><code>AbstractAnnData$as_ReticulateAnnData()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_Seurat"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_Seurat'><code>AbstractAnnData$as_Seurat()</code></a></span></li>
   <li><span class="pkg-link" data-pkg="anndataR" data-topic="AbstractAnnData" data-id="as_SingleCellExperiment"><a href='../../anndataR/html/AbstractAnnData.html#method-AbstractAnnData-as_SingleCellExperiment'><code>AbstractAnnData$as_SingleCellExperiment()</code></a></span></li>
@@ -106,6 +106,7 @@ Other AnnData classes:
   uns = NULL,
   shape = NULL,
   mode = c("a", "r", "r+", "w", "w-", "x"),
+  backed = FALSE,
   compression = c("none", "gzip", "blosc", "zstd", "lzma", "bz2", "zlib", "lz4"),
   zarr_format = NULL
 )}
@@ -129,6 +130,8 @@ already exits, other arguments must be \code{NULL}.}
 both \code{X} or \code{obs} and \code{var} are not provided.}
       \item{\code{mode}}{The mode to open the Zarr file. See \code{\link[=as_ZarrAnnData]{as_ZarrAnnData()}} for
 details}
+      \item{\code{backed}}{Whether the object is disk backed. See \code{\link[=as_ZarrAnnData]{as_ZarrAnnData()}}
+for details}
       \item{\code{compression}}{The compression algorithm to use. See
 \code{\link[=as_ZarrAnnData]{as_ZarrAnnData()}} for details}
       \item{\code{zarr_format}}{The Zarr format to use. See
@@ -260,6 +263,20 @@ file will be overwritten.
   \subsection{Usage}{
     \if{html}{\out{<div class="r">}}
     \preformatted{ZarrAnnData$uns_keys()}
+    \if{html}{\out{</div>}}
+  }
+}
+
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ZarrAnnData-as_InMemoryAnnData"></a>}}
+\if{latex}{\out{\hypertarget{method-ZarrAnnData-as_InMemoryAnnData}{}}}
+\subsection{\code{ZarrAnnData$as_InMemoryAnnData()}}{
+  Convert to an \code{\link{InMemoryAnnData}}. Any backed
+(\code{DelayedArray}) slots are materialized into ordinary in-memory
+matrices: an in-memory object should not stay tied to an on-disk file.
+  \subsection{Usage}{
+    \if{html}{\out{<div class="r">}}
+    \preformatted{ZarrAnnData$as_InMemoryAnnData()}
     \if{html}{\out{</div>}}
   }
 }

--- a/man/as_ZarrAnnData.Rd
+++ b/man/as_ZarrAnnData.Rd
@@ -9,6 +9,7 @@ as_ZarrAnnData(
   file,
   compression = c("none", "gzip", "blosc", "zstd", "lzma", "bz2", "zlib", "lz4"),
   mode = c("w-", "r", "r+", "a", "w", "x"),
+  backed = FALSE,
   zarr_format = NULL
 )
 }
@@ -29,6 +30,10 @@ Zarr file. Can be one of \code{"none"}, \code{"gzip"}, \code{"blosc"}, \code{"zs
 \item \code{w} creates a file, truncating any existing ones
 \item \verb{w-}/\code{x} are synonyms, creating a file and failing if it already exists
 }}
+
+\item{backed}{Whether the object is disk backed and returns
+\link[DelayedArray:DelayedArray]{DelayedArray::DelayedArray} object for matrix data. Can only be \code{TRUE}
+when \code{mode == "r"}.}
 
 \item{zarr_format}{The format to use when creating the Zarr store. Should be
 either 2 or 3 for Zarr v2 or v3 formats, respectively. The default can also

--- a/man/read_zarr.Rd
+++ b/man/read_zarr.Rd
@@ -8,6 +8,7 @@ read_zarr(
   path,
   as = c("InMemoryAnnData", "ZarrAnnData", "SingleCellExperiment", "Seurat"),
   mode = c("r", "r+", "a", "w", "w-", "x"),
+  backed = FALSE,
   ...
 )
 }
@@ -33,6 +34,10 @@ read_zarr(
 \item \code{w} creates a file, truncating any existing ones.
 \item \verb{w-}/\code{x} are synonyms, creating a file and failing if it already exists.
 }}
+
+\item{backed}{Whether to read the H5AD file in backed mode, returning an
+object containing \link[DelayedArray:DelayedMatrix]{DelayedArray::DelayedMatrix} matrices. Which slots are
+backed depends on the value of \code{as}.}
 
 \item{...}{Extra arguments provided to the \verb{as_*} conversion function for the
 object specified by \code{as}}

--- a/man/read_zarr.Rd
+++ b/man/read_zarr.Rd
@@ -35,7 +35,7 @@ read_zarr(
 \item \verb{w-}/\code{x} are synonyms, creating a file and failing if it already exists.
 }}
 
-\item{backed}{Whether to read the H5AD file in backed mode, returning an
+\item{backed}{Whether to read the Zarr store in backed mode, returning an
 object containing \link[DelayedArray:DelayedMatrix]{DelayedArray::DelayedMatrix} matrices. Which slots are
 backed depends on the value of \code{as}.}
 

--- a/tests/testthat/test-Zarr-read.R
+++ b/tests/testthat/test-Zarr-read.R
@@ -218,7 +218,6 @@ for (zarr_format in c(2, 3)) {
     suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
 
     backed <- read_zarr(store, as = "ZarrAnnData", backed = TRUE)
-    withr::defer(backed$close())
     sce_backed <- backed$as_SingleCellExperiment()
 
     ad2 <- as_AnnData(sce_backed)

--- a/tests/testthat/test-Zarr-read.R
+++ b/tests/testthat/test-Zarr-read.R
@@ -52,6 +52,179 @@ for (zarr_format in c(2, 3)) {
     expect_s4_class(mat, "dgRMatrix")
     expect_equal(dim(mat), c(50, 100))
   })
+  
+  test_that(
+    paste("reading backed Zarr", zarr_format, "sparse matrices works"), {
+    mat <- read_zarr_sparse_array(
+      store,
+      "layers/csc_counts",
+      type = "csc",
+      backed = TRUE
+    )
+    expect_s4_class(mat, "DelayedMatrix")
+    seed <- DelayedArray::seed(mat)
+    expect_s4_class(seed, "CSR_ZarrSparseMatrixSeed")
+    expect_identical(DelayedArray::type(seed), "double")
+    expect_true(DelayedArray::is_sparse(seed))
+    expect_equal(dim(mat), c(50, 100))
+    
+    mat <- read_zarr_sparse_array(
+      store,
+      "layers/counts",
+      type = "csr",
+      backed = TRUE
+    )
+    expect_s4_class(mat, "DelayedMatrix")
+    seed <- DelayedArray::seed(mat)
+    expect_s4_class(seed, "CSC_ZarrSparseMatrixSeed")
+    expect_identical(DelayedArray::type(seed), "double")
+    expect_true(DelayedArray::is_sparse(seed))
+    expect_equal(dim(mat), c(50, 100))
+  })
+  
+  # INVARIANT: backed dense reads must equal an INDEPENDENT eager read
+  test_that(
+    "backed dense reads are value-identical to independent eager reads", 
+    {
+      for (nm in c("layers/dense_counts", "layers/dense_X")) {
+        eager <- read_zarr_dense_array_base(store, nm)
+        backed <- read_zarr_dense_array(store, nm, backed = TRUE)
+        expect_s4_class(backed, "DelayedMatrix")
+        expect_equal(as.matrix(backed), eager)
+        raw <- Rarr::read_zarr_array(file.path(store, nm)) # on-disk orientation is vars x obs
+        expect_equal(as.matrix(backed), raw, ignore_attr = TRUE)
+      }
+    }
+  )
+  
+  # INVARIANT: backed sparse reads must equal independent eager reads and stay
+  # sparse.
+  test_that("backed sparse reads are value-identical to independent eager reads", {
+    cases <- list(
+      list(name = "layers/csc_counts", type = "csc_matrix"),
+      list(name = "layers/counts", type = "csr_matrix")
+    )
+    for (case in cases) {
+      eager <- read_zarr_sparse_array_base(store, case$name, type = case$type)
+      backed <- read_zarr_sparse_array(
+        store,
+        case$name,
+        type = case$type,
+        backed = TRUE
+      )
+      expect_s4_class(backed, "DelayedMatrix")
+      expect_true(DelayedArray::is_sparse(backed))
+      expect_equal(as.matrix(backed), as.matrix(eager))
+    }
+  })
+  
+  # INVARIANT: a backed ZarrAnnData exposes the same matrices (values, dimnames,
+  # orientation) as an eager one, for every matrix-valued slot.
+  test_that("backed ZarrAnnData slots equal eager slots", {
+    eager <- ZarrAnnData$new(store, mode = "r")
+    backed <- ZarrAnnData$new(store, mode = "r", backed = TRUE)
+    
+    expect_s4_class(backed$X, "DelayedMatrix")
+    expect_equal(as.matrix(backed$X), as.matrix(eager$X))
+    # TODO: backed dimnames are a list of NULL ?
+    # expect_identical(dimnames(backed$X), dimnames(eager$X))
+    
+    for (k in eager$layers_keys()) {
+      expect_equal(
+        as.matrix(backed$layers[[k]]),
+        as.matrix(eager$layers[[k]]),
+        info = paste("layer", k)
+      )
+    }
+    for (k in names(eager$obsm)) {
+      expect_equal(
+        as.matrix(backed$obsm[[k]]),
+        as.matrix(eager$obsm[[k]]),
+        info = paste("obsm", k)
+      )
+    }
+    for (k in names(eager$obsp)) {
+      expect_equal(
+        as.matrix(backed$obsp[[k]]),
+        as.matrix(eager$obsp[[k]]),
+        info = paste("obsp", k)
+      )
+    }
+  })
+  
+  # INVARIANT: a backed matrix reads lazily by file path, so it must keep working
+  # after the source AnnData is closed and garbage-collected.
+  test_that("backed matrices stay readable after the source AnnData is closed", {
+    eager <- ZarrAnnData$new(store, mode = "r")
+    expected <- as.matrix(eager$X)
+
+    backed <- ZarrAnnData$new(store, mode = "r", backed = TRUE)
+    x_backed <- backed$X
+    expect_s4_class(x_backed, "DelayedMatrix")
+    rm(backed)
+    gc()
+    
+    expect_equal(as.matrix(x_backed), expected)
+  })
+  
+  # Regression test: subsetting a backed AnnData must stay lazy AND apply the
+  # subset.
+  test_that("subsetting a backed AnnData stays lazy and subsets correctly", {
+    backed <- ZarrAnnData$new(store, mode = "r", backed = TRUE)
+    eager <- ZarrAnnData$new(store, mode = "r")
+    
+    oi <- c(1, 3, 5, 7, 9)
+    vi <- 1:10
+    vb <- backed[oi, vi]
+    ve <- eager[oi, vi]
+    
+    expect_s4_class(vb$X, "DelayedMatrix")
+    expect_equal(dim(vb$X), c(length(oi), length(vi)))
+    expect_equal(as.matrix(vb$X), as.matrix(ve$X))
+  })
+  
+  # Regression test: converting a backed AnnData to InMemory must materialize its
+  # DelayedArrays into ordinary in-memory matrices
+  test_that("converting a backed AnnData to InMemory materializes its matrices", {
+    backed <- ZarrAnnData$new(store, mode = "r", backed = TRUE)
+    im <- backed$as_InMemoryAnnData()
+    
+    expect_false(inherits(im$X, "DelayedArray"))
+    expect_equal(as.matrix(im$X), as.matrix(backed$X))
+  })
+  
+  # INVARIANT: a backed SingleCellExperiment keeps its assays lazy (DelayedMatrix)
+  # and value-equal to an eager conversion.
+  test_that("backed SingleCellExperiment has lazy assays equal to eager ones", {
+    suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
+    
+    backed <- read_zarr(store, as = "ZarrAnnData", backed = TRUE)
+    eager <- read_zarr(store, as = "ZarrAnnData")
+    
+    sce_b <- backed$as_SingleCellExperiment()
+    sce_e <- eager$as_SingleCellExperiment()
+    for (a in SummarizedExperiment::assayNames(sce_e)) {
+      expect_s4_class(SummarizedExperiment::assay(sce_b, a), "DelayedMatrix")
+      expect_equal(
+        as.matrix(SummarizedExperiment::assay(sce_b, a)),
+        as.matrix(SummarizedExperiment::assay(sce_e, a)),
+        info = paste("assay", a)
+      )
+    }
+  })
+  
+  # Regression test (issue #387, reported by LouiseDck): converting a backed SCE
+  # back to AnnData must preserve shape.
+  test_that("round-trip of a backed SCE back to AnnData preserves shape", {
+    suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
+    
+    backed <- read_zarr(store, as = "ZarrAnnData", backed = TRUE)
+    withr::defer(backed$close())
+    sce_backed <- backed$as_SingleCellExperiment()
+    
+    ad2 <- as_AnnData(sce_backed)
+    expect_equal(ad2$shape(), backed$shape())
+  })
 
   test_that(paste("reading Zarr", zarr_format, "recarrays works"), {
     array_list <- read_zarr_rec_array(

--- a/tests/testthat/test-Zarr-read.R
+++ b/tests/testthat/test-Zarr-read.R
@@ -26,6 +26,22 @@ for (zarr_format in c(2, 3)) {
     expect_type(mat, "double")
     expect_equal(dim(mat), c(50, 100))
   })
+  
+  test_that(paste("reading backed Zarr", zarr_format, "dense matrices works"), {
+    mat <- read_zarr_dense_array(store, "layers/dense_counts", backed = TRUE)
+    expect_s4_class(mat, "DelayedMatrix")
+    seed <- DelayedArray::seed(mat)
+    expect_identical(DelayedArray::type(seed), "integer")
+    expect_false(DelayedArray::is_sparse(seed))
+    expect_equal(dim(mat), c(50, 100))
+    
+    mat <- read_zarr_dense_array(store, "layers/dense_X", backed = TRUE)
+    expect_s4_class(mat, "DelayedMatrix")
+    seed <- DelayedArray::seed(mat)
+    expect_identical(DelayedArray::type(seed), "double")
+    expect_false(DelayedArray::is_sparse(seed))
+    expect_equal(dim(mat), c(50, 100))
+  })
 
   test_that(paste("reading Zarr", zarr_format, "sparse matrices works"), {
     mat <- read_zarr_sparse_array(store, "layers/csc_counts", type = "csc")

--- a/tests/testthat/test-Zarr-read.R
+++ b/tests/testthat/test-Zarr-read.R
@@ -26,7 +26,7 @@ for (zarr_format in c(2, 3)) {
     expect_type(mat, "double")
     expect_equal(dim(mat), c(50, 100))
   })
-  
+
   test_that(paste("reading backed Zarr", zarr_format, "dense matrices works"), {
     mat <- read_zarr_dense_array(store, "layers/dense_counts", backed = TRUE)
     expect_s4_class(mat, "DelayedMatrix")
@@ -34,7 +34,7 @@ for (zarr_format in c(2, 3)) {
     expect_identical(DelayedArray::type(seed), "integer")
     expect_false(DelayedArray::is_sparse(seed))
     expect_equal(dim(mat), c(50, 100))
-    
+
     mat <- read_zarr_dense_array(store, "layers/dense_X", backed = TRUE)
     expect_s4_class(mat, "DelayedMatrix")
     seed <- DelayedArray::seed(mat)
@@ -52,51 +52,50 @@ for (zarr_format in c(2, 3)) {
     expect_s4_class(mat, "dgRMatrix")
     expect_equal(dim(mat), c(50, 100))
   })
-  
+
   test_that(
-    paste("reading backed Zarr", zarr_format, "sparse matrices works"), {
-    mat <- read_zarr_sparse_array(
-      store,
-      "layers/csc_counts",
-      type = "csc",
-      backed = TRUE
-    )
-    expect_s4_class(mat, "DelayedMatrix")
-    seed <- DelayedArray::seed(mat)
-    expect_s4_class(seed, "CSR_ZarrSparseMatrixSeed")
-    expect_identical(DelayedArray::type(seed), "double")
-    expect_true(DelayedArray::is_sparse(seed))
-    expect_equal(dim(mat), c(50, 100))
-    
-    mat <- read_zarr_sparse_array(
-      store,
-      "layers/counts",
-      type = "csr",
-      backed = TRUE
-    )
-    expect_s4_class(mat, "DelayedMatrix")
-    seed <- DelayedArray::seed(mat)
-    expect_s4_class(seed, "CSC_ZarrSparseMatrixSeed")
-    expect_identical(DelayedArray::type(seed), "double")
-    expect_true(DelayedArray::is_sparse(seed))
-    expect_equal(dim(mat), c(50, 100))
-  })
-  
-  # INVARIANT: backed dense reads must equal an INDEPENDENT eager read
-  test_that(
-    "backed dense reads are value-identical to independent eager reads", 
+    paste("reading backed Zarr", zarr_format, "sparse matrices works"),
     {
-      for (nm in c("layers/dense_counts", "layers/dense_X")) {
-        eager <- read_zarr_dense_array_base(store, nm)
-        backed <- read_zarr_dense_array(store, nm, backed = TRUE)
-        expect_s4_class(backed, "DelayedMatrix")
-        expect_equal(as.matrix(backed), eager)
-        raw <- Rarr::read_zarr_array(file.path(store, nm)) # on-disk orientation is vars x obs
-        expect_equal(as.matrix(backed), raw, ignore_attr = TRUE)
-      }
+      mat <- read_zarr_sparse_array(
+        store,
+        "layers/csc_counts",
+        type = "csc",
+        backed = TRUE
+      )
+      expect_s4_class(mat, "DelayedMatrix")
+      seed <- DelayedArray::seed(mat)
+      expect_s4_class(seed, "CSR_ZarrSparseMatrixSeed")
+      expect_identical(DelayedArray::type(seed), "double")
+      expect_true(DelayedArray::is_sparse(seed))
+      expect_equal(dim(mat), c(50, 100))
+
+      mat <- read_zarr_sparse_array(
+        store,
+        "layers/counts",
+        type = "csr",
+        backed = TRUE
+      )
+      expect_s4_class(mat, "DelayedMatrix")
+      seed <- DelayedArray::seed(mat)
+      expect_s4_class(seed, "CSC_ZarrSparseMatrixSeed")
+      expect_identical(DelayedArray::type(seed), "double")
+      expect_true(DelayedArray::is_sparse(seed))
+      expect_equal(dim(mat), c(50, 100))
     }
   )
-  
+
+  # INVARIANT: backed dense reads must equal an INDEPENDENT eager read
+  test_that("backed dense reads are value-identical to independent eager reads", {
+    for (nm in c("layers/dense_counts", "layers/dense_X")) {
+      eager <- read_zarr_dense_array_base(store, nm)
+      backed <- read_zarr_dense_array(store, nm, backed = TRUE)
+      expect_s4_class(backed, "DelayedMatrix")
+      expect_equal(as.matrix(backed), eager)
+      raw <- Rarr::read_zarr_array(file.path(store, nm)) # on-disk orientation is vars x obs
+      expect_equal(as.matrix(backed), raw, ignore_attr = TRUE)
+    }
+  })
+
   # INVARIANT: backed sparse reads must equal independent eager reads and stay
   # sparse.
   test_that("backed sparse reads are value-identical to independent eager reads", {
@@ -117,18 +116,18 @@ for (zarr_format in c(2, 3)) {
       expect_equal(as.matrix(backed), as.matrix(eager))
     }
   })
-  
+
   # INVARIANT: a backed ZarrAnnData exposes the same matrices (values, dimnames,
   # orientation) as an eager one, for every matrix-valued slot.
   test_that("backed ZarrAnnData slots equal eager slots", {
     eager <- ZarrAnnData$new(store, mode = "r")
     backed <- ZarrAnnData$new(store, mode = "r", backed = TRUE)
-    
+
     expect_s4_class(backed$X, "DelayedMatrix")
     expect_equal(as.matrix(backed$X), as.matrix(eager$X))
     # TODO: backed dimnames are a list of NULL ?
     # expect_identical(dimnames(backed$X), dimnames(eager$X))
-    
+
     for (k in eager$layers_keys()) {
       expect_equal(
         as.matrix(backed$layers[[k]]),
@@ -151,7 +150,7 @@ for (zarr_format in c(2, 3)) {
       )
     }
   })
-  
+
   # INVARIANT: a backed matrix reads lazily by file path, so it must keep working
   # after the source AnnData is closed and garbage-collected.
   test_that("backed matrices stay readable after the source AnnData is closed", {
@@ -163,44 +162,44 @@ for (zarr_format in c(2, 3)) {
     expect_s4_class(x_backed, "DelayedMatrix")
     rm(backed)
     gc()
-    
+
     expect_equal(as.matrix(x_backed), expected)
   })
-  
+
   # Regression test: subsetting a backed AnnData must stay lazy AND apply the
   # subset.
   test_that("subsetting a backed AnnData stays lazy and subsets correctly", {
     backed <- ZarrAnnData$new(store, mode = "r", backed = TRUE)
     eager <- ZarrAnnData$new(store, mode = "r")
-    
+
     oi <- c(1, 3, 5, 7, 9)
     vi <- 1:10
     vb <- backed[oi, vi]
     ve <- eager[oi, vi]
-    
+
     expect_s4_class(vb$X, "DelayedMatrix")
     expect_equal(dim(vb$X), c(length(oi), length(vi)))
     expect_equal(as.matrix(vb$X), as.matrix(ve$X))
   })
-  
+
   # Regression test: converting a backed AnnData to InMemory must materialize its
   # DelayedArrays into ordinary in-memory matrices
   test_that("converting a backed AnnData to InMemory materializes its matrices", {
     backed <- ZarrAnnData$new(store, mode = "r", backed = TRUE)
     im <- backed$as_InMemoryAnnData()
-    
+
     expect_false(inherits(im$X, "DelayedArray"))
     expect_equal(as.matrix(im$X), as.matrix(backed$X))
   })
-  
+
   # INVARIANT: a backed SingleCellExperiment keeps its assays lazy (DelayedMatrix)
   # and value-equal to an eager conversion.
   test_that("backed SingleCellExperiment has lazy assays equal to eager ones", {
     suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
-    
+
     backed <- read_zarr(store, as = "ZarrAnnData", backed = TRUE)
     eager <- read_zarr(store, as = "ZarrAnnData")
-    
+
     sce_b <- backed$as_SingleCellExperiment()
     sce_e <- eager$as_SingleCellExperiment()
     for (a in SummarizedExperiment::assayNames(sce_e)) {
@@ -212,16 +211,16 @@ for (zarr_format in c(2, 3)) {
       )
     }
   })
-  
+
   # Regression test (issue #387, reported by LouiseDck): converting a backed SCE
   # back to AnnData must preserve shape.
   test_that("round-trip of a backed SCE back to AnnData preserves shape", {
     suppressWarnings(skip_if_not_installed("SingleCellExperiment"))
-    
+
     backed <- read_zarr(store, as = "ZarrAnnData", backed = TRUE)
     withr::defer(backed$close())
     sce_backed <- backed$as_SingleCellExperiment()
-    
+
     ad2 <- as_AnnData(sce_backed)
     expect_equal(ad2$shape(), backed$shape())
   })


### PR DESCRIPTION
## Description

This is a draft PR that adds new support for reading dense and sparse matrices as Zarr-backed DelayedArray objects. 

* Use the **{ZarrArray}** package for lazily reading dense and sparse arrays from Zarr stores
* Add a `backed` argument to `ZarrAnnData`, `read_zarr` etc.
* Conversion of Zarr-backed AnnData objects to SingleCellExperiment/Seurat while keeping dense and sparse matrices as **{ZarrArray}** objects.

## Checklist

**Before review**

- [ ] Update and regenerate man pages (needed?)
- [x] Add/update tests
- [ ] Add/update examples in vignettes (needed?)
- [x] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [ ] Bump devel version
