### PR TITLE
Pin Python mudata to < 0.4 in the usage_python vignette

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # anndataR devel
 
+- Pin Python `mudata` to `< 0.4` in the `usage_python` vignette, as mudata 0.4 can no longer read the legacy example `.h5mu` file (PR #512, issue #511).
 - Support the `anndata.AnnData` class name used by Python anndata >= 0.13 in `py_to_r()` and `ReticulateAnnData`, and warn that anndata >= 0.13 is not fully supported yet (PR #510, issue #499).
 - Add support for `nullable-string-array` elements in H5AD and Zarr (PR #480)
 - Check `RELEASE_*` branches against Bioconductor release and `devel` against Bioconductor devel, instead of checking `devel` against both (PR #502).

--- a/vignettes/usage_python.Rmd
+++ b/vignettes/usage_python.Rmd
@@ -10,7 +10,9 @@ vignette: >
 
 ```{r, include = FALSE}
 # Set up reticulate and check for required Python packages.
-reticulate::py_require("mudata")
+# TEMP(mudata<0.4): mudata 0.4 cannot read the legacy example .h5mu file,
+# revert once issue #511 is resolved
+reticulate::py_require("mudata<0.4")
 # TEMP(anndata<0.13.0): pin and the scanpy lower bound were added in PR #481,
 # revert once anndataR supports Python anndata >= 0.13.0
 reticulate::py_require("scanpy>=1.10")
@@ -107,7 +109,7 @@ seurat_obj
 Install required Python packages if needed:
 
 ```{r mudata_setup, eval=FALSE}
-reticulate::py_install("mudata")
+reticulate::py_install("mudata<0.4")
 ```
 
 ```{r load_mudata}


### PR DESCRIPTION
**Related to:** #511

## Description

Pin Python `mudata` to `< 0.4` in the `usage_python` vignette. mudata 0.4 reads modality groups via anndata's IO registry and can no longer read the legacy example `.h5mu` file, which has been breaking all CI runs since 2026-08-17. See #511 for the full analysis and the plan to remove the pin again.

## Checklist

**Before review**

- [ ] Update and regenerate man pages (not needed)
- [ ] Add/update tests (not needed)
- [x] Add/update examples in vignettes
- [ ] Pass CI checks

**Before merge**

- [x] Update `NEWS`
- [ ] Bump devel version
