### PR TITLE
Pin mudata<0.4 in the CI workflows

### DIFF
--- a/.github/workflows/R-CMD-check-bioc.yaml
+++ b/.github/workflows/R-CMD-check-bioc.yaml
@@ -118,8 +118,10 @@ jobs:
           reticulate::install_miniconda()
           # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
           # supports Python anndata >= 0.13.0
+          # TEMP(mudata<0.4): mudata 0.4 cannot read the legacy example .h5mu
+          # file, revert once issue #511 is resolved
           reticulate::py_install(
-            c("scanpy", "mudata", "anndata<0.13.0"),
+            c("scanpy", "mudata<0.4", "anndata<0.13.0"),
             method = "conda",
             channel = "conda-forge"
           )

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -51,7 +51,9 @@ jobs:
         run: |
           # TEMP(anndata<0.13.0): pin added in PR #481, revert once anndataR
           # supports Python anndata >= 0.13.0
-          pip install "anndata<0.13.0" scanpy mudata
+          # TEMP(mudata<0.4): mudata 0.4 cannot read the legacy example .h5mu
+          # file, revert once issue #511 is resolved
+          pip install "anndata<0.13.0" scanpy "mudata<0.4"
           echo "RETICULATE_PYTHON=$(which python3)" >> ~/.Renviron
           echo "Python configured for reticulate:" && Rscript -e 'reticulate::py_config()'
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # anndataR devel
 
+- Pin Python `mudata` to `< 0.4` in the pkgdown and macOS-Intel check workflows as well, because `py_require()` pins in the vignette are ignored when `RETICULATE_PYTHON` is forced (PR #518, issue #511).
 - Pin Python `mudata` to `< 0.4` in the `usage_python` vignette, as mudata 0.4 can no longer read the legacy example `.h5mu` file (PR #512, issue #511).
 - Support the `anndata.AnnData` class name used by Python anndata >= 0.13 in `py_to_r()` and `ReticulateAnnData`, and warn that anndata >= 0.13 is not fully supported yet (PR #510, issue #499).
 - Add support for `nullable-string-array` elements in H5AD and Zarr (PR #480)


### PR DESCRIPTION
**Related to:** #511

## Description

The `py_require("mudata<0.4")` pin from #512 is ignored on the jobs that install Python packages themselves and then force `RETICULATE_PYTHON`, so pkgdown still got mudata 0.4.1 and failed on the `load_mudata_example` chunk.

* pin `mudata<0.4` in the `pip install` line of `pkgdown.yaml`
* pin `mudata<0.4` in the conda `py_install()` call for macOS-Intel in `R-CMD-check-bioc.yaml`

## Checklist

**Before review**

- [x] Update and regenerate man pages (n/a)
- [x] Add/update tests (n/a)
- [x] Add/update examples in vignettes (n/a)
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [x] Bump devel version (not needed)
