### PR TITLE
Strip the as.na attribute before h5diff comparisons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # anndataR devel
 
+- Also remove the `as.na` attribute that rhdf5 2.57.12 adds to datasets containing `NA` when comparing R-written files to Python-written ones in the roundtrip tests (PR #519, issue #517).
 - Pin Python `mudata` to `< 0.4` in the pkgdown and macOS-Intel check workflows as well, because `py_require()` pins in the vignette are ignored when `RETICULATE_PYTHON` is forced (PR #518, issue #511).
 - Pin Python `mudata` to `< 0.4` in the `usage_python` vignette, as mudata 0.4 can no longer read the legacy example `.h5mu` file (PR #512, issue #511).
 - Support the `anndata.AnnData` class name used by Python anndata >= 0.13 in `py_to_r()` and `ReticulateAnnData`, and warn that anndata >= 0.13 is not fully supported yet (PR #510, issue #499).

--- a/R/write_hdf5_helpers.R
+++ b/R/write_hdf5_helpers.R
@@ -308,22 +308,28 @@ hdf5_write_attribute <- function(
 #' @name name Name of the element within the HDF5 file
 #'
 #' @details
-#' rhdf5 adds a `rhdf5-NA.OK` attribute to elements which doesn't affect the
-#' validity of the HDF5 but shows up when comparing to a file created by Python.
-#' This function removes those attributes from an element so files are
-#' comparable.
+#' rhdf5 adds a `rhdf5-NA.OK` attribute (and, since rhdf5 2.57.12, an `as.na`
+#' attribute) to elements containing `NA`. They don't affect the validity of
+#' the HDF5 but show up when comparing to a file created by Python. This
+#' function removes those attributes from an element so files are comparable.
 #'
 #' @noRd
 hdf5_clear_rhdf5_attributes <- function(hdf5_file, name) {
   hdf5_file$open_and_defer_close()
 
+  rhdf5_attrs <- c("rhdf5-NA.OK", "as.na")
+
   h5obj <- rhdf5::H5Oopen(hdf5_file$handle, name)
   h5type <- rhdf5::H5Iget_type(h5obj)
-  rhdf5_na_ok_exists <- rhdf5::H5Aexists(h5obj, "rhdf5-NA.OK")
+  attrs_exist <- vapply(
+    rhdf5_attrs,
+    function(attr) rhdf5::H5Aexists(h5obj, attr),
+    logical(1)
+  )
   rhdf5::H5Oclose(h5obj)
 
-  if (rhdf5_na_ok_exists) {
-    rhdf5::h5deleteAttribute(hdf5_file$handle, name, "rhdf5-NA.OK")
+  for (attr in rhdf5_attrs[attrs_exist]) {
+    rhdf5::h5deleteAttribute(hdf5_file$handle, name, attr)
   }
 
   if (h5type == "H5I_GROUP") {

--- a/tests/testthat/test-HDF5-write.R
+++ b/tests/testthat/test-HDF5-write.R
@@ -485,3 +485,36 @@ test_that("writing a backed AnnData materializes its DelayedMatrix slots", {
   expect_false(inherits(roundtrip$X, "DelayedArray"))
   expect_equal(as.matrix(roundtrip$X), as.matrix(backed$X))
 })
+
+test_that("hdf5_clear_rhdf5_attributes() removes rhdf5 bookkeeping attributes", {
+  file <- withr::local_tempfile(fileext = ".h5")
+  rhdf5::h5createFile(file)
+  hdf5_file <- HDF5File$new(file)
+
+  write_h5ad_element(c(1, 2, 3), hdf5_file, "vector", compression = "none")
+  hdf5_write_attribute(hdf5_file, "vector", "rhdf5-NA.OK", TRUE)
+  hdf5_write_attribute(hdf5_file, "vector", "as.na", TRUE)
+
+  hdf5_clear_rhdf5_attributes(hdf5_file, "vector")
+
+  hdf5_file$open_and_defer_close()
+  attrs <- rhdf5::h5readAttributes(hdf5_file$handle, "vector", native = FALSE)
+  expect_false(any(c("rhdf5-NA.OK", "as.na") %in% names(attrs)))
+  expect_true(all(c("encoding-type", "encoding-version") %in% names(attrs)))
+})
+
+test_that("hdf5_clear_rhdf5_attributes() recurses into groups", {
+  file <- withr::local_tempfile(fileext = ".h5")
+  rhdf5::h5createFile(file)
+  hdf5_file <- HDF5File$new(file)
+
+  csc <- as(matrix(c(1, 0, 0, 2), nrow = 2), "CsparseMatrix")
+  write_h5ad_element(csc, hdf5_file, "sparse", compression = "none")
+  hdf5_write_attribute(hdf5_file, "sparse/data", "as.na", TRUE)
+
+  hdf5_clear_rhdf5_attributes(hdf5_file, "sparse")
+
+  hdf5_file$open_and_defer_close()
+  attrs <- rhdf5::h5readAttributes(hdf5_file$handle, "sparse/data", native = FALSE)
+  expect_false("as.na" %in% names(attrs))
+})


### PR DESCRIPTION
**Related to:** Closes #517

## Description

rhdf5 2.57.12 restored an `as.na` attribute on datasets containing `NA`, which made 24 roundtrip comparisons fail on `h5diff` exit status even though the data is identical. This is only used in the tests, and is harmless once rhdf5 drops the attribute again.

* `hdf5_clear_rhdf5_attributes()` now deletes `as.na` alongside `rhdf5-NA.OK`
* add unit tests for the helper, including the group recursion

## Checklist

**Before review**

- [x] Update and regenerate man pages (n/a, `@noRd`)
- [x] Add/update tests
- [x] Add/update examples in vignettes (n/a)
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [x] Bump devel version (not needed)
