### PR TITLE
Skip tests while rhdf5 2.57.12 warns about NA_character_

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # anndataR devel
 
+- Skip the H5AD file-closure tests while rhdf5 2.57.12 emits a spurious `NA_character_` warning for numeric datasets containing `NA`, tracked as a known issue until the fix from Huber-group-EMBL/rhdf5#242 reaches Bioconductor devel (PR #520).
 - Also remove the `as.na` attribute that rhdf5 2.57.12 adds to datasets containing `NA` when comparing R-written files to Python-written ones in the roundtrip tests (PR #519, issue #517).
 - Pin Python `mudata` to `< 0.4` in the pkgdown and macOS-Intel check workflows as well, because `py_require()` pins in the vignette are ignored when `RETICULATE_PYTHON` is forced (PR #518, issue #511).
 - Pin Python `mudata` to `< 0.4` in the `usage_python` vignette, as mudata 0.4 can no longer read the legacy example `.h5mu` file (PR #512, issue #511).

--- a/inst/known_issues.yaml
+++ b/inst/known_issues.yaml
@@ -15,3 +15,32 @@ known_issues:
     proposed_solution: Investigate if this is a problem or not.
     to_investigate: True
     to_fix: False
+  - backend: HDF5AnnData
+    slot:
+      - X
+      - layers
+      - obs
+      - var
+      - obsm
+      - varm
+      - obsp
+      - varp
+      - uns
+    dtype:
+      - numeric_with_nas
+      - numeric_matrix_with_nas
+      - numeric_dense_with_nas
+      - numeric_csparse_with_nas
+      - numeric_rsparse_with_nas
+      - integer_matrix_with_nas
+      - integer_csparse_with_nas
+      - integer_rsparse_with_nas
+    process: [write]
+    error_message: |
+      Writing NA_character_ in fixed-length string datasets is fragile and deprecated.
+      In particular, it will write NA_character_ as the string 'NA' in the HDF5 file.
+      Use variable-length strings instead.
+    description: rhdf5 2.57.12 emits a spurious NA_character_ warning when a numeric dataset containing NA or NaN is written into a pre-created dataset.
+    proposed_solution: The check in rhdf5's h5writeDataset.array() lacks a storage.mode(obj) == "character" guard on the existing-dataset branch (https://github.com/Huber-group-EMBL/rhdf5/blob/1682d4b493d0ddc9e46cba78a141b780bb8390e8/R/h5write.R#L405-L417). Reported in Huber-group-EMBL/rhdf5#241 and fixed in Huber-group-EMBL/rhdf5#242; remove this entry and the skips in test-h5ad-fileclosure.R once the fixed rhdf5 is in Bioconductor devel.
+    to_investigate: False
+    to_fix: False

--- a/tests/testthat/test-h5ad-fileclosure.R
+++ b/tests/testthat/test-h5ad-fileclosure.R
@@ -1,3 +1,5 @@
+known_issues <- read_known_issues()
+
 dummy <- generate_dataset(
   n_obs = 10L,
   n_vars = 20L,
@@ -6,13 +8,25 @@ dummy <- generate_dataset(
 
 file <- tempfile(pattern = "h5ad_write_", fileext = ".h5ad")
 
+# TEMP(rhdf5 2.57.12): the dummy dataset contains numeric elements with NAs
+# which trigger a spurious rhdf5 warning, see inst/known_issues.yaml
+known_issue <- message_if_known(
+  backend = "HDF5AnnData",
+  slot = "layers",
+  dtype = "numeric_matrix_with_nas",
+  process = "write",
+  known_issues = known_issues
+)
+
 test_that("writing H5AD works", {
+  skip_if(!is.null(known_issue), message = known_issue)
   expect_no_condition({
     write_h5ad(dummy, file, mode = "w")
   })
 })
 
 test_that("reading H5AD to InMemoryAnnData closes file", {
+  skip_if(!is.null(known_issue), message = known_issue)
   expect_no_condition({
     read_h5ad(file)
     write_h5ad(dummy, file, mode = "w")
@@ -20,6 +34,7 @@ test_that("reading H5AD to InMemoryAnnData closes file", {
 })
 
 test_that("closing HDF5AnnData file works", {
+  skip_if(!is.null(known_issue), message = known_issue)
   expect_no_condition({
     adata <- read_h5ad(file, as = "HDF5AnnData")
     write_h5ad(dummy, file, mode = "w")


### PR DESCRIPTION
**Related to:** Huber-group-EMBL/rhdf5#241, Huber-group-EMBL/rhdf5#242

## Description

rhdf5 2.57.12 warns about `NA_character_` for every numeric dataset containing `NA`/`NaN` that is written into a pre-created dataset (the check lacks a character guard, see the permalink in `known_issues.yaml`). anndataR always pre-creates datasets, so `write_h5ad()` of the test dataset emits 48 of these and the `expect_no_condition()` tests in `test-h5ad-fileclosure.R` fail on every platform.

* add a known-issue entry describing the upstream bug
* skip the three file-closure tests while the entry exists

To revert once rhdf5 with the fix from Huber-group-EMBL/rhdf5#242 is in Bioconductor devel.

## Checklist

**Before review**

- [x] Update and regenerate man pages (n/a)
- [x] Add/update tests
- [x] Add/update examples in vignettes (n/a)
- [ ] Pass CI checks

**Before merge**

- [ ] Update `NEWS`
- [x] Bump devel version (not needed)
